### PR TITLE
Change release workflow details

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     flags: [-trimpath, -v]
     goos: [linux]
     goarch: [amd64, arm64]
-    binary: bootsrap
+    binary: bootstrap
 
 archives:
   - format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,11 +7,11 @@ builds:
     flags: [-trimpath, -v]
     goos: [linux]
     goarch: [amd64, arm64]
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    binary: bootsrap
 
 archives:
   - format: zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
 
 changelog:
   use: github-native


### PR DESCRIPTION
I've updated the release workflow for the required migration from go1.x runtime version for Lambda to the provided.al2 runtime.