### PR TITLE
fix: don't duplicate logger fields

### DIFF
--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -21,6 +21,7 @@ func main() {
 			return fmt.Errorf("could not configure X-Ray: %w", err)
 		}
 
+		logger := logger
 		if lc, ok := lambdacontext.FromContext(ctx); ok {
 			logger = logger.With("aws_request_id", lc.AwsRequestID)
 		}

--- a/internal/auto_scaler.go
+++ b/internal/auto_scaler.go
@@ -61,7 +61,7 @@ func (s AutoScaler) Scale(ctx context.Context, cfg RuntimeConfig) error {
 		}
 
 		for _, instance := range instances {
-			logger = logger.With("instance_id", *instance.InstanceId)
+			logger := logger.With("instance_id", *instance.InstanceId)
 			instanceAge := time.Since(*instance.LaunchTime)
 
 			logger = logger.With(
@@ -116,7 +116,7 @@ func (s AutoScaler) Scale(ctx context.Context, cfg RuntimeConfig) error {
 
 		_, instanceID, _ := worker.InstanceIdentity()
 
-		logger = logger.With(
+		logger := logger.With(
 			"worker_id", worker.ID,
 			"instance_id", instanceID,
 		)


### PR DESCRIPTION
Now, we have duplicated fields in logs:
```
{... "msg":"scaling down ASG and killing worker", ... , "aws_request_id": "...", "aws_request_id": "...", ... "worker_id": "...", "instance_id": "...", "worker_id": "...", "instance_id": "...", ... }
```
We should reuse the logger, and just pass with new fields to the new logger variable.