### PR TITLE
fix: handle detached not terminated instances

### DIFF
--- a/internal/auto_scaler_test.go
+++ b/internal/auto_scaler_test.go
@@ -3,7 +3,9 @@ package internal_test
 import (
 	"bytes"
 	"context"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/stretchr/testify/mock"
@@ -68,7 +70,7 @@ func TestAutoScalerScalingUp(t *testing.T) {
 		MaxSize:              ptr(int32(3)),
 		DesiredCapacity:      ptr(int32(2)),
 		Instances: []types.Instance{
-			{},
+			{InstanceId: ptr("instance")},
 		},
 	}, nil)
 	ctrl.On("ScaleUpASG", mock.Anything, int32(2)).Return(nil)
@@ -107,12 +109,60 @@ func TestAutoScalerScalingDown(t *testing.T) {
 		MaxSize:              ptr(int32(3)),
 		DesiredCapacity:      ptr(int32(2)),
 		Instances: []types.Instance{
-			{},
-			{},
+			{InstanceId: ptr("instance")},
+			{InstanceId: ptr("instance2")},
 		},
 	}, nil)
 	ctrl.On("DrainWorker", mock.Anything, "1").Return(true, nil)
 	ctrl.On("KillInstance", mock.Anything, "instance").Return(nil)
+	err := scaler.Scale(context.Background(), cfg)
+	require.NoError(t, err)
+}
+
+func TestAutoScalerDetachedNotTerminatedInstances(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, nil)
+
+	cfg := internal.RuntimeConfig{}
+
+	ctrl := new(MockController)
+	defer ctrl.AssertExpectations(t)
+
+	scaler := internal.NewAutoScaler(ctrl, slog.New(h))
+
+	ctrl.On("GetWorkerPool", mock.Anything).Return(&internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				ID:       "1",
+				Metadata: `{"asg_id": "group", "instance_id": "instance"}`,
+			},
+			{
+				ID:       "2",
+				Drained:  true,
+				Metadata: `{"asg_id": "group", "instance_id": "detached"}`,
+			},
+		},
+		PendingRuns: 2,
+	}, nil)
+	ctrl.On("GetAutoscalingGroup", mock.Anything).Return(&types.AutoScalingGroup{
+		AutoScalingGroupName: ptr("group"),
+		MinSize:              ptr(int32(1)),
+		MaxSize:              ptr(int32(3)),
+		DesiredCapacity:      ptr(int32(2)),
+		Instances: []types.Instance{
+			{InstanceId: ptr("instance")},
+		},
+	}, nil)
+	ctrl.On("KillInstance", mock.Anything, "detached").Return(nil)
+	output := []ec2types.Instance{{
+		InstanceId: ptr("detached"),
+		LaunchTime: nullable(time.Now().Add(-time.Hour)),
+	}}
+	ctrl.On(
+		"DescribeInstances",
+		mock.Anything,
+		[]string{"detached"},
+	).Return(output, nil)
 	err := scaler.Scale(context.Background(), cfg)
 	require.NoError(t, err)
 }

--- a/internal/auto_scaler_test.go
+++ b/internal/auto_scaler_test.go
@@ -3,11 +3,11 @@ package internal_test
 import (
 	"bytes"
 	"context"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slog"

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -2,13 +2,13 @@ package internal_test
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/franela/goblin"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/spacelift-io/awsautoscalr/internal"
 )

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -2,6 +2,8 @@ package internal_test
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
@@ -10,6 +12,46 @@ import (
 
 	"github.com/spacelift-io/awsautoscalr/internal"
 )
+
+func TestState_StrayInstances(t *testing.T) {
+	const asgName = "asg-name"
+	const instanceID = "instance-id"
+	const failedToTerminateInstanceID = "instance-id2"
+	asg := &types.AutoScalingGroup{
+		AutoScalingGroupName: nullable(asgName),
+		MinSize:              nullable(int32(1)),
+		MaxSize:              nullable(int32(5)),
+		DesiredCapacity:      nullable(int32(3)),
+		Instances: []types.Instance{
+			{
+				InstanceId: nullable(instanceID),
+			},
+		},
+	}
+	workerPool := &internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      asgName,
+					"instance_id": instanceID,
+				}),
+			},
+			{
+				Drained: true,
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      asgName,
+					"instance_id": failedToTerminateInstanceID,
+				}),
+			},
+		},
+	}
+
+	state, err := internal.NewState(workerPool, asg)
+	require.NoError(t, err)
+
+	strayInstances := state.StrayInstances()
+	assert.Equal(t, []string{failedToTerminateInstanceID}, strayInstances)
+}
 
 func TestState(t *testing.T) {
 	g := goblin.Goblin(t)


### PR DESCRIPTION
*The problem*:
The current logic is the next: 
* The controller scales down and calls KillInstance [here](https://github.com/spacelift-io/ec2-workerpool-autoscaler/blob/main/internal/auto_scaler.go#L135)
* Inside KillInstance, we [DetachInstances](https://github.com/spacelift-io/ec2-workerpool-autoscaler/blob/main/internal/controller.go#L243) from the ASG and then try to [Terminate the instance](https://github.com/spacelift-io/ec2-workerpool-autoscaler/blob/main/internal/controller.go#L264)
* During the termination process, theres a network issue or something which causes Loren's autoscaler to actually time out when terminating
* On the next autoscaling invocation we try to [decide the scale direction](https://github.com/spacelift-io/ec2-workerpool-autoscaler/blob/main/internal/auto_scaler.go#L92). But since the [workers in the pool and the size of the ASG dont match](https://github.com/spacelift-io/ec2-workerpool-autoscaler/blob/main/internal/state.go#L99), we decide not to scale.


The autoscaler will forever be stuck here if the autoscaling logic detaches the instance but cannot terminate it.

*Solution*:
To fix this we need to include in the StrayInstances detached but not terminated instances, so they will be handled during the kill stray instances logic.

Should solve this issue https://github.com/spacelift-io/ec2-workerpool-autoscaler/issues/16.