### PR TITLE
feat: allow downloading latest release

### DIFF
--- a/iac/download.sh
+++ b/iac/download.sh
@@ -3,9 +3,23 @@ set -ex
 
 # Download the data.
 code_version=$1
-code_architecture=$2
+export code_architecture=$2
 
-curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
+if [ "$code_version" != "latest" ]; then
+  code_version="tags/$code_version"
+fi
+
+release=$(curl -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/${code_version}" | jq -r --arg ZIP "ec2-workerpool-autoscaler_linux_$code_architecture.zip" '.assets[] | select(.name==$ZIP)')
+
+release_date=$(echo $release | jq -r '.created_at')
+download_url=$(echo $release | jq -r '.browser_download_url')
+
+echo "Downloading Details:"
+echo "  Release Name: $code_version"
+echo "  Release Date: $release_date"
+echo "  Download URL: $download_url"
+
+curl -L -o lambda.zip $download_url
 
 mkdir -p lambda
 cd lambda

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -6,13 +6,7 @@ variable "autoscaling_group_arn" {
 variable "autoscaler_version" {
   type        = string
   description = "Version of the autoscaler to deploy"
-  default     = "v0.3.0"
-}
-
-variable "autoscaling_frequency" {
-  type        = number
-  description = "How often to run the autoscaler, in minutes"
-  default     = 5
+  default     = "latest"
 }
 
 variable "spacelift_api_key_id" {


### PR DESCRIPTION
- Changed download.sh to download the latest version by default (still supporting version pinning).
- Removed unused terraform variable.