### PR TITLE
feat: add ability to set permissions_boundary for autoscaler role

### DIFF
--- a/iac/policy.tf
+++ b/iac/policy.tf
@@ -86,4 +86,6 @@ resource "aws_iam_role" "autoscaler" {
     name   = "ec2-autoscaler-${var.worker_pool_id}"
     policy = data.aws_iam_policy_document.autoscaler.json
   }
+
+  permissions_boundary = var.autoscaler_permissions_boundary
 }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -93,3 +93,9 @@ variable "security_group_ids" {
   description = "optional security group IDs to provide to the autoscaler VPC configuration"
   default     = [""]
 }
+
+variable "autoscaler_permissions_boundary" {
+  type        = string
+  default     = null
+  description = "ARN of the policy that is used to set the permissions boundary for the autoscale IAM role."
+}


### PR DESCRIPTION
Adds ability to set a permissions boundary for the autoscaling role.  This would enable me to use this autoscaling capability in my environment (we require permissions boundaries on all IAM resources).