### PR TITLE
Revert "Removes region variable since it is unused"

### DIFF
--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -67,6 +67,11 @@ variable "base_name" {
   default     = null
 }
 
+variable "region" {
+  type        = string
+  description = "AWS Region where the provider will operate"
+}
+
 variable "autoscaler_s3_package" {
   type = object({
     bucket         = string


### PR DESCRIPTION
Even though this input is not used in this module, it is still used downstream in the workerpool module! And since that module is currently using an unversioned reference to _this_ module, removing the `region` input broke that module.

In the long run, I really think the dependency needs to be reversed, such that the terraform workerpool project hosts a reusable "lambda" submodule and keeps up all the terraform module conventions, and this autoscaler project hosts just the lambda code as it seems it intended.

See also: https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/111

Reverts spacelift-io/ec2-workerpool-autoscaler#26