### PR TITLE
Properly print the worker ID when ASG_ID is improperly set on the worker's metadata

### DIFF
--- a/internal/state.go
+++ b/internal/state.go
@@ -46,8 +46,12 @@ func NewState(workerPool *WorkerPool, asg *types.AutoScalingGroup, cfg RuntimeCo
 			return nil, err
 		}
 
+		if string(groupID) == "" {
+			return nil, fmt.Errorf("worker %s has empty ASG ID in metadata", worker.ID)
+		}
+
 		if string(groupID) != *asg.AutoScalingGroupName {
-			return nil, fmt.Errorf("incorrect worker ASG: %s", groupID)
+			return nil, fmt.Errorf("worker %s has incorrect ASG: %s (expected: %s)", worker.ID, groupID, *asg.AutoScalingGroupName)
 		}
 
 		workersByInstanceID[instanceID] = worker

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -131,9 +131,26 @@ func TestState(t *testing.T) {
 					})
 				})
 
+				g.Describe("when the worker has an empty ASG ID", func() {
+					g.BeforeEach(func() {
+						workerPool.Workers = []internal.Worker{{
+							ID: "worker-123",
+							Metadata: mustJSON(map[string]any{
+								"asg_id":      "",
+								"instance_id": "i-1234567890",
+							}),
+						}}
+					})
+
+					g.It("should return an error", func() {
+						Expect(err).To(MatchError("worker worker-123 has empty ASG ID in metadata"))
+					})
+				})
+
 				g.Describe("when the worker does not belong to the ASG", func() {
 					g.BeforeEach(func() {
 						workerPool.Workers = []internal.Worker{{
+							ID: "worker-456",
 							Metadata: mustJSON(map[string]any{
 								"asg_id":      "other-asg",
 								"instance_id": "i-1234567890",
@@ -142,7 +159,7 @@ func TestState(t *testing.T) {
 					})
 
 					g.It("should return an error", func() {
-						Expect(err).To(MatchError("incorrect worker ASG: other-asg"))
+						Expect(err).To(MatchError("worker worker-456 has incorrect ASG: other-asg (expected: asg-name)"))
 					})
 				})
 			})


### PR DESCRIPTION
The current implementation doesn't tell you which worker has invalid metadata.  This makes it hard to debug because the error makes it seem like theres something wrong with the ASG and not wrong with the metadata. The logs end up printing something like ```2025/10/28 04:06:50 
{
    "errorMessage": "could not create state: incorrect worker ASG: ",
    "errorType": "wrapError"
}```

You then have to go the spacelift UI or use the API to search the worker with invalid metadata, looking something like this:
<img width="1966" height="132" alt="image" src="https://github.com/user-attachments/assets/d1c9f79e-98fc-481e-8db5-95b96d2d2add" />
