### PR TITLE
feat: defensive scaling

### DIFF
--- a/internal/auto_scaler_test.go
+++ b/internal/auto_scaler_test.go
@@ -163,3 +163,148 @@ func TestAutoScalerDetachedNotTerminatedInstances(t *testing.T) {
 	err := scaler.Scale(t.Context(), cfg)
 	require.NoError(t, err)
 }
+func TestAutoScalerDesiredCapacitySanityCheck(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, nil)
+
+	cfg := internal.RuntimeConfig{
+		AutoscalingMaxCreate: 20,
+	}
+
+	ctrl := new(MockController)
+	defer ctrl.AssertExpectations(t)
+
+	scaler := internal.NewAutoScaler(ctrl, slog.New(h))
+
+	// Simulate AWS outage scenario: ASG desired capacity is 79,
+	// but we only have 3 workers and 5 pending runs
+	ctrl.On("GetWorkerPool", mock.Anything).Return(&internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				ID:       "1",
+				Metadata: `{"asg_id": "group", "instance_id": "i-1"}`,
+			},
+			{
+				ID:       "2",
+				Metadata: `{"asg_id": "group", "instance_id": "i-2"}`,
+			},
+			{
+				ID:       "3",
+				Metadata: `{"asg_id": "group", "instance_id": "i-3"}`,
+			},
+		},
+		PendingRuns: 5,
+	}, nil)
+
+	ctrl.On("GetAutoscalingGroup", mock.Anything).Return(&internal.AutoScalingGroup{
+		Name:            "group",
+		MinSize:         3,
+		MaxSize:         100,
+		DesiredCapacity: 79, // Suspiciously high!
+		Instances: []internal.Instance{
+			{ID: "i-1"},
+			{ID: "i-2"},
+			{ID: "i-3"},
+		},
+	}, nil)
+
+	// Expected behavior:
+	// 1. Autoscaler should first reset capacity to 8 (3 workers + 5 pending runs)
+	// 2. Then normal scaling logic continues: with 3 idle workers and 5 pending runs,
+	//    it needs 2 more workers, so scales from 8 to 10
+	ctrl.On("ScaleUpASG", mock.Anything, 8).Return(nil).Once()
+	ctrl.On("ScaleUpASG", mock.Anything, 10).Return(nil).Once()
+
+	err := scaler.Scale(t.Context(), cfg)
+	require.NoError(t, err)
+
+	// Verify that error logs contain the sanity check message
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "ASG desired capacity is suspiciously high")
+	require.Contains(t, logOutput, "attempting to reset ASG desired capacity")
+}
+
+func TestAutoScalerDesiredCapacitySanityCheckRespectsMinSize(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, nil)
+
+	cfg := internal.RuntimeConfig{
+		AutoscalingMaxCreate: 20,
+	}
+
+	ctrl := new(MockController)
+	defer ctrl.AssertExpectations(t)
+
+	scaler := internal.NewAutoScaler(ctrl, slog.New(h))
+
+	// ASG desired capacity is 50, but we have 0 workers and 0 pending runs
+	// Reset should respect min size of 3
+	ctrl.On("GetWorkerPool", mock.Anything).Return(&internal.WorkerPool{
+		Workers:     []internal.Worker{},
+		PendingRuns: 0,
+	}, nil)
+
+	ctrl.On("GetAutoscalingGroup", mock.Anything).Return(&internal.AutoScalingGroup{
+		Name:            "group",
+		MinSize:         3,
+		MaxSize:         100,
+		DesiredCapacity: 50, // Suspiciously high!
+		Instances:       []internal.Instance{},
+	}, nil)
+
+	// Expected behavior: autoscaler should reset capacity to 3 (min size)
+	ctrl.On("ScaleUpASG", mock.Anything, 3).Return(nil)
+
+	err := scaler.Scale(t.Context(), cfg)
+	require.NoError(t, err)
+}
+
+func TestAutoScalerDesiredCapacitySanityCheckNoResetWhenReasonable(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, nil)
+
+	cfg := internal.RuntimeConfig{
+		AutoscalingMaxCreate: 20,
+	}
+
+	ctrl := new(MockController)
+	defer ctrl.AssertExpectations(t)
+
+	scaler := internal.NewAutoScaler(ctrl, slog.New(h))
+
+	// ASG desired capacity is 10, we have 8 workers and 2 pending runs
+	// This is reasonable (8 + 2 = 10), so no reset should occur
+	ctrl.On("GetWorkerPool", mock.Anything).Return(&internal.WorkerPool{
+		Workers: []internal.Worker{
+			{ID: "1", Metadata: `{"asg_id": "group", "instance_id": "i-1"}`},
+			{ID: "2", Metadata: `{"asg_id": "group", "instance_id": "i-2"}`},
+			{ID: "3", Metadata: `{"asg_id": "group", "instance_id": "i-3"}`},
+			{ID: "4", Metadata: `{"asg_id": "group", "instance_id": "i-4"}`},
+			{ID: "5", Metadata: `{"asg_id": "group", "instance_id": "i-5"}`},
+			{ID: "6", Metadata: `{"asg_id": "group", "instance_id": "i-6"}`},
+			{ID: "7", Metadata: `{"asg_id": "group", "instance_id": "i-7"}`},
+			{ID: "8", Metadata: `{"asg_id": "group", "instance_id": "i-8"}`},
+		},
+		PendingRuns: 2,
+	}, nil)
+
+	ctrl.On("GetAutoscalingGroup", mock.Anything).Return(&internal.AutoScalingGroup{
+		Name:            "group",
+		MinSize:         3,
+		MaxSize:         100,
+		DesiredCapacity: 10,
+		Instances: []internal.Instance{
+			{ID: "i-1"}, {ID: "i-2"}, {ID: "i-3"}, {ID: "i-4"},
+			{ID: "i-5"}, {ID: "i-6"}, {ID: "i-7"}, {ID: "i-8"},
+		},
+	}, nil)
+
+	// No ScaleUpASG call expected for sanity check - capacity is reasonable
+
+	err := scaler.Scale(t.Context(), cfg)
+	require.NoError(t, err)
+
+	// Verify that error logs do NOT contain the sanity check message
+	logOutput := buf.String()
+	require.NotContains(t, logOutput, "ASG desired capacity is suspiciously high")
+}

--- a/internal/runtime_config.go
+++ b/internal/runtime_config.go
@@ -6,11 +6,12 @@ type RuntimeConfig struct {
 	SpaceliftAPIEndpoint   string `env:"SPACELIFT_API_KEY_ENDPOINT,notEmpty"`
 	SpaceliftWorkerPoolID  string `env:"SPACELIFT_WORKER_POOL_ID,notEmpty"`
 
-	AutoscalingScaleDownDelay int    `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
-	AutoscalingGroupARN       string `env:"AUTOSCALING_GROUP_ARN,notEmpty"`
-	AutoscalingRegion         string `env:"AUTOSCALING_REGION,notEmpty"`
-	AutoscalingMaxKill        int    `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
-	AutoscalingMaxCreate      int    `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
+	AutoscalingScaleDownDelay      int    `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
+	AutoscalingGroupARN            string `env:"AUTOSCALING_GROUP_ARN,notEmpty"`
+	AutoscalingRegion              string `env:"AUTOSCALING_REGION,notEmpty"`
+	AutoscalingMaxKill             int    `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
+	AutoscalingMaxCreate           int    `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
+	AutoscalingCapacitySanityCheck int    `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
 }
 
 func (r RuntimeConfig) GroupKeyAndID() (string, string) {


### PR DESCRIPTION
## Summary

Adds defensive scaling safeguards to detect and recover from unreasonably high ASG desired capacity values that can occur during AWS service disruptions or external modifications.

## Motivation

During AWS service disruptions, the Auto Scaling Group desired capacity can be incorrectly set to extremely high values (e.g., 79 instances when only 3 workers and 5 pending runs exist). This can cause massive unnecessary scaling, leading to significant cost overruns and operational issues. We need a mechanism to detect these anomalies and automatically reset to sane capacity values.

## Changes

- **Sanity check logic in autoscaler**: Before normal scaling operations, calculate expected maximum capacity based on valid workers, pending runs, and scaling buffer. If ASG desired capacity significantly exceeds this value, log an error and reset to a reasonable value.
- **Graceful handling of invalid worker metadata**: Workers with missing or invalid metadata are now logged and skipped rather than causing fatal errors, preventing invalid workers from blocking autoscaling operations.
- **New `ValidWorkerCount()` method**: Track only workers with valid metadata separately from total worker count, ensuring scaling decisions are based on actual functional workers.
- **Updated scaling decision logic**: All scaling decisions now use `validWorkerCount` instead of total worker count to prevent stray/invalid workers from affecting capacity calculations.
- **Comprehensive test coverage**: Added tests for sanity check scenarios including high capacity detection, min/max size boundary handling, and reasonable capacity validation.

## Features

- **Configurable sanity threshold**: New `AUTOSCALING_CAPACITY_SANITY_CHECK` environment variable (defaults to 10) controls the excess capacity threshold that triggers defensive reset.
- **Automatic capacity recovery**: When suspicious capacity is detected, automatically resets to `valid_workers + pending_runs` (respecting ASG min/max constraints).
- **Non-fatal error handling**: Invalid worker metadata no longer blocks autoscaling; workers are skipped with warning logs and operations continue.
- **Detailed logging**: Error and warning logs include full context (current capacity, valid workers, pending runs, expected capacity, difference) for debugging and alerting.

## Usage

The sanity check runs automatically on every scaling cycle. To customize the threshold:

```bash
# Set threshold to 20 instances instead of default 10
export AUTOSCALING_CAPACITY_SANITY_CHECK=20
```

The sanity check triggers when:
```
excess_capacity = asg_desired_capacity - (valid_workers + pending_runs + max_create)
if excess_capacity >= sanity_threshold:
    # Reset capacity to valid_workers + pending_runs
```

When triggered, logs will show:
- `ERROR`: "ASG desired capacity is suspiciously high" with full diagnostic context
- `WARN`: "attempting to reset ASG desired capacity to sane value" with old/new values
- `INFO`: "successfully reset ASG desired capacity" on successful recovery