### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ The utility requires the following AWS permissions to be granted to the IAM role
 - `ec2:TerminateInstances` in the region the autoscaling group is in to terminate the instances;
 - `ssm:GetParameter` on the SSM Parameter Store parameter storing the Spacelift API key secret;
 
-The Spacelift API key needs to have administrator privileges for the [space](https://docs.spacelift.io/concepts/spaces/) where the worker pool is defined.
+The Spacelift API key needs to have
+- `Space:Read` for the Space the worker exists
+- `Worker Pool:Drain Worker` 
 
 ## Observability
 


### PR DESCRIPTION
Fixed Readme for the granular permissions, Tested and works with API key to scale .

Previously showed admin permissions required. 

Now it is 
Space read 
Workerpool drain
 
<img width="504" height="298" alt="image" src="https://github.com/user-attachments/assets/906e1194-b7a0-4497-8bea-aee251d7ca03" />

<img width="504" height="298" alt="image" src="https://github.com/user-attachments/assets/7b358f5c-4e3c-43b6-b5cf-8410378caaba" />
