### PR TITLE
fix: map azure ProvisioningState to LifecycleState for state.go compatibility

### DIFF
--- a/internal/azure_controller_test.go
+++ b/internal/azure_controller_test.go
@@ -305,7 +305,13 @@ func TestAzureGetAutoscalingGroup_Success_ReturnsGroup(t *testing.T) {
 		{
 			InstanceID: stringPtr("vm-2"),
 			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: stringPtr("Succeeded"),
+				ProvisioningState: stringPtr("Creating"),
+			},
+		},
+		{
+			InstanceID: stringPtr("vm-3"),
+			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+				ProvisioningState: stringPtr("Deleting"),
 			},
 		},
 	}
@@ -324,7 +330,12 @@ func TestAzureGetAutoscalingGroup_Success_ReturnsGroup(t *testing.T) {
 	require.Equal(t, 3, group.DesiredCapacity)
 	require.Equal(t, 0, group.MinSize)
 	require.Equal(t, 6, group.MaxSize)
-	require.Len(t, group.Instances, 2)
+	require.Len(t, group.Instances, 3)
+
+	// Verify lifecycle states are mapped correctly
+	require.Equal(t, internal.LifecycleStateInService, group.Instances[0].LifecycleState)
+	require.Equal(t, "Creating", group.Instances[1].LifecycleState)
+	require.Equal(t, internal.LifecycleStateTerminating, group.Instances[2].LifecycleState)
 }
 
 // GetWorkerPool tests - verifies Spacelift worker pool integration (cloud-agnostic)


### PR DESCRIPTION
There is a comment in azure_controller.go that says "Map to standard LifecycleState constants for state.go compatibility", but the code didn't actually do that. This adds that mapping and updates the GetAutoscalingGroup test to verify it correctly maps the states that are used (InService and Terminating).

Without this, workers will never end up in the inServiceInstanceIDs set in the State struct, which I think means it will not properly handle stray instances (which may or may not be an issue with Azure? It seems like ScaleSet VMs maybe can't be strays?). Whether or not that actually currently causes an issue, it should probably be fixed in case there are any code changes in the future that rely on inServiceInstanceIDs for anything else.