### PR TITLE
feat: add automated license checking

### DIFF
--- a/.github/workflows/job_check_licenses.yml
+++ b/.github/workflows/job_check_licenses.yml
@@ -13,6 +13,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Checkout license check action
+        uses: actions/checkout@v6
+        with:
+          repository: spacelift-io/upload-dependencies-to-notion
+          ref: main
+          path: .github/actions/license-check
+          token: ${{ secrets.GH_PAT }}
+
 #      - name: "Get license configuration"
 #        run: |
 #          ignored_packages=$(cat .github/licenses.yml | yq -r '.ignored_packages | join(",")')
@@ -23,7 +31,7 @@ jobs:
         with: { go-version-file: go.mod }
 
       - name: Check licenses
-        uses: spacelift-io/upload-dependencies-to-notion/.github/actions/check-go-licenses@main
+        uses: ./.github/actions/license-check/.github/actions/check-go-licenses
         with:
           package_paths: "./cmd/cloudrun ./cmd/local ./cmd/lambda ./cmd/azurefunc"
 #          ignored_packages: "${{ env.IGNORED_PACKAGES }}"

--- a/.github/workflows/job_check_licenses.yml
+++ b/.github/workflows/job_check_licenses.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Check licenses
         uses: spacelift-io/upload-dependencies-to-notion/.github/actions/check-go-licenses@main
         with:
-          package_paths: "./cmd/spacelift ./cmd/spacelift-launcher ./cmd/spacelift-worker"
+          package_paths: "./cmd/cloudrun ./cmd/local ./cmd/lambda ./cmd/azurefunc"
 #          ignored_packages: "${{ env.IGNORED_PACKAGES }}"

--- a/.github/workflows/job_check_licenses.yml
+++ b/.github/workflows/job_check_licenses.yml
@@ -1,0 +1,29 @@
+name: Check Go Dependency Licenses
+
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  check-go-dependency-licenses:
+    name: "Check Go dependency licenses"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+#      - name: "Get license configuration"
+#        run: |
+#          ignored_packages=$(cat .github/licenses.yml | yq -r '.ignored_packages | join(",")')
+#          echo "IGNORED_PACKAGES=${ignored_packages}" > "$GITHUB_ENV"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with: { go-version-file: go.mod }
+
+      - name: Check licenses
+        uses: spacelift-io/upload-dependencies-to-notion/.github/actions/check-go-licenses@main
+        with:
+          package_paths: "./cmd/spacelift ./cmd/spacelift-launcher ./cmd/spacelift-worker"
+#          ignored_packages: "${{ env.IGNORED_PACKAGES }}"


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for automated Go dependency license checking on PRs
- Uses the shared `spacelift-io/upload-dependencies-to-notion` license check action

## Changes

Adds `.github/workflows/job_check_licenses.yml` — a new workflow that runs on pull requests and via `workflow_call` to verify Go dependency licenses are compliant.

1. **Workflow triggers**: Runs on `pull_request` and supports `workflow_call` for reuse from other workflows
2. **License check**: Uses `spacelift-io/upload-dependencies-to-notion/.github/actions/check-go-licenses@main` to scan all cmd packages (`cloudrun`, `local`, `lambda`, `azurefunc`)
3. **Scaffolding for ignored packages**: Commented-out support for a `.github/licenses.yml` config to exclude specific packages from checks (ready to enable when needed)