### PR TITLE
fix: use DesiredCapacity instead of instance count in scaling guard

### DIFF
--- a/internal/auto_scaler_test.go
+++ b/internal/auto_scaler_test.go
@@ -68,7 +68,9 @@ func TestAutoScalerScalingUp(t *testing.T) {
 	var buf bytes.Buffer
 	h := slog.NewTextHandler(&buf, nil)
 
-	cfg := internal.RuntimeConfig{}
+	cfg := internal.RuntimeConfig{
+		AutoscalingMaxCreate: 2,
+	}
 
 	ctrl := new(MockController)
 	defer ctrl.AssertExpectations(t)
@@ -90,7 +92,7 @@ func TestAutoScalerScalingUp(t *testing.T) {
 		Name:            "group",
 		MinSize:         1,
 		MaxSize:         3,
-		DesiredCapacity: 2,
+		DesiredCapacity: 1,
 		Instances: []internal.Instance{
 			{ID: "instance"},
 		},
@@ -240,11 +242,11 @@ func TestAutoScalerDesiredCapacitySanityCheck(t *testing.T) {
 	}, nil)
 
 	// Expected behavior:
-	// 1. Autoscaler should first reset capacity to 8 (3 workers + 5 pending runs)
-	// 2. Then normal scaling logic continues: with 3 idle workers and 5 pending runs,
-	//    it needs 2 more workers, so scales from 8 to 10
+	// 1. Sanity check resets capacity to 8 (3 workers + 5 pending runs)
+	// 2. The scaling guard sees desired capacity (8) != valid workers (3) and
+	//    correctly blocks further scaling this tick. This also prevents
+	//    double-counting pending runs that were already accounted for in the reset.
 	ctrl.On("ScaleUpASG", mock.Anything, 8).Return(nil).Once()
-	ctrl.On("ScaleUpASG", mock.Anything, 10).Return(nil).Once()
 
 	err := scaler.Scale(t.Context(), cfg)
 	require.NoError(t, err)
@@ -253,6 +255,7 @@ func TestAutoScalerDesiredCapacitySanityCheck(t *testing.T) {
 	logOutput := buf.String()
 	require.Contains(t, logOutput, "desired capacity is suspiciously high")
 	require.Contains(t, logOutput, "attempting to reset desired capacity to sane value")
+	require.Contains(t, logOutput, "not scaling the ASG")
 }
 
 func TestAutoScalerDesiredCapacitySanityCheckRespectsMinSize(t *testing.T) {

--- a/internal/state.go
+++ b/internal/state.go
@@ -157,10 +157,10 @@ func (s *State) detachedNotTerminatedInstances() []string {
 }
 
 func (s *State) Decide(maxCreate, maxKill int) Decision {
-	if s.validWorkerCount != len(s.ASG.Instances) {
+	if s.validWorkerCount != s.ASG.DesiredCapacity {
 		return Decision{
 			ScalingDirection: ScalingDirectionNone,
-			Comments:         []string{"number of valid workers does not match the number of instances in the ASG"},
+			Comments:         []string{"number of valid workers does not match the desired capacity of the ASG"},
 		}
 	}
 

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -354,9 +354,9 @@ func TestScalableWorkers_ReturnsIdleWorkers(t *testing.T) {
 func TestDecide_NoWorkersNoPendingRunsNoInstances_NoScaling(t *testing.T) {
 	asg := &internal.AutoScalingGroup{
 		Name:            "asg-name",
-		MinSize:         1,
+		MinSize:         0,
 		MaxSize:         2,
-		DesiredCapacity: 2,
+		DesiredCapacity: 0,
 	}
 	workerPool := &internal.WorkerPool{}
 	cfg := internal.RuntimeConfig{
@@ -393,7 +393,159 @@ func TestDecide_NoWorkersNoPendingRunsWithInstances_NoScalingNotInBalance(t *tes
 
 	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
 	require.Zero(t, decision.ScalingSize)
-	require.ElementsMatch(t, []string{"number of valid workers does not match the number of instances in the ASG"}, decision.Comments)
+	require.ElementsMatch(t, []string{"number of valid workers does not match the desired capacity of the ASG"}, decision.Comments)
+}
+
+func TestDecide_TerminatingInstanceDoesNotBlockScaleUp(t *testing.T) {
+	// Scenario: autoscaler previously scaled down, the instance is mid-deletion
+	// (still visible in the instance list) but desired capacity is already decremented.
+	// A new run arrives and the autoscaler should scale up without being blocked.
+	asg := &internal.AutoScalingGroup{
+		Name:            "asg-name",
+		MinSize:         0,
+		MaxSize:         5,
+		DesiredCapacity: 0, // Already decremented by the scale-down
+		Instances: []internal.Instance{
+			{ID: "i-dying", LifecycleState: internal.LifecycleStateTerminating},
+		},
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 1,
+	}
+	cfg := internal.RuntimeConfig{}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(1, 1)
+
+	require.Equal(t, internal.ScalingDirectionUp, decision.ScalingDirection)
+	require.Equal(t, 1, decision.ScalingSize)
+}
+
+func TestDecide_CreatingInstancePreventsDoubleScaleUp(t *testing.T) {
+	// Scenario: autoscaler previously scaled up (desired=2), one instance is
+	// running with a registered worker, the other is still creating. The guard
+	// should block to prevent a second scale-up for the same demand.
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         5,
+		DesiredCapacity: 2,
+		Instances: []internal.Instance{
+			{ID: "i-running", LifecycleState: internal.LifecycleStateInService},
+			{ID: "i-creating", LifecycleState: "CREATING"},
+		},
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 1,
+		Workers: []internal.Worker{
+			{
+				ID: "worker-1",
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      asgName,
+					"instance_id": "i-running",
+				}),
+			},
+		},
+	}
+	cfg := internal.RuntimeConfig{}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(2, 2)
+
+	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
+	require.ElementsMatch(t, []string{"number of valid workers does not match the desired capacity of the ASG"}, decision.Comments)
+}
+
+func TestDecide_MixedStateTerminatingInstanceWithPendingRuns(t *testing.T) {
+	// Scenario: 2 workers active, 1 instance was scaled down and is terminating.
+	// Desired capacity already decremented to 2. New pending runs arrive.
+	// The guard should pass and allow scale-up.
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 2, // Decremented from 3 when termination was initiated
+		Instances: []internal.Instance{
+			{ID: "i-1", LifecycleState: internal.LifecycleStateInService},
+			{ID: "i-2", LifecycleState: internal.LifecycleStateInService},
+			{ID: "i-dying", LifecycleState: internal.LifecycleStateTerminating},
+		},
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 3,
+		Workers: []internal.Worker{
+			{
+				ID:   "worker-1",
+				Busy: true,
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      asgName,
+					"instance_id": "i-1",
+				}),
+			},
+			{
+				ID:   "worker-2",
+				Busy: true,
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      asgName,
+					"instance_id": "i-2",
+				}),
+			},
+		},
+	}
+	cfg := internal.RuntimeConfig{}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(5, 2)
+
+	require.Equal(t, internal.ScalingDirectionUp, decision.ScalingDirection)
+	require.Equal(t, 3, decision.ScalingSize)
+}
+
+func TestDecide_PreemptedInstanceWithReplacementCreating(t *testing.T) {
+	// Scenario: a VM was preempted (terminating), the cloud is auto-replacing it
+	// (creating), and the old worker is still registered in Spacelift.
+	// Desired capacity unchanged. Guard should pass since validWorkers == desired.
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         1,
+		MaxSize:         5,
+		DesiredCapacity: 1, // Unchanged — cloud will replace the preempted instance
+		Instances: []internal.Instance{
+			{ID: "i-preempted", LifecycleState: internal.LifecycleStateTerminating},
+			{ID: "i-replacement", LifecycleState: "CREATING"},
+		},
+	}
+	workerPool := &internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				ID: "old-worker",
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      asgName,
+					"instance_id": "i-preempted",
+				}),
+			},
+		},
+	}
+	cfg := internal.RuntimeConfig{}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(2, 2)
+
+	// validWorkers=1, desired=1 → guard passes.
+	// No pending runs, 1 scalable worker → no scaling needed.
+	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
+	require.ElementsMatch(t, []string{"autoscaling group exactly at the right size"}, decision.Comments)
 }
 
 func TestDecide_NoWorkersPendingRunsAtMaxSize_NoScaling(t *testing.T) {


### PR DESCRIPTION
The scaling guard in Decide() compared validWorkerCount against len(ASG.Instances), which includes instances in Terminating/Deleting state. On GCP and Azure, deleted instances remain visible in list APIs until fully removed, even though desired capacity is already decremented. This caused the guard to block all scaling decisions (including scale-up for pending runs) while instances were mid-deletion.

By comparing against DesiredCapacity instead, the guard correctly ignores dying instances whose capacity has already been accounted for. This also prevents double scale-up when the cloud is slow to create new instances (DesiredCapacity reflects the target, not the current count).

Additionally fixes a bug in the sanity check where pending runs were double-counted: the sanity reset already included pending runs in the new capacity, but Decide() would add them again.