### PR TITLE
fix(aws): handle stray instance removal when ASG is at minimum capacity

### DIFF
--- a/internal/auto_scaler.go
+++ b/internal/auto_scaler.go
@@ -28,10 +28,12 @@ type ControllerInterface interface {
 	GetWorkerPool(ctx context.Context) (out *WorkerPool, err error)
 	DrainWorker(ctx context.Context, workerID string) (drained bool, err error)
 	// KillInstance terminates an instance and removes it from the scaling group.
-	// Implementations MUST ensure that the group's desired capacity is decremented
-	// as part of this operation (either explicitly or via platform auto-adjustment).
-	// The caller does NOT separately adjust capacity during scale-down.
-	KillInstance(ctx context.Context, instanceID string) (err error)
+	// decrementCapacity controls whether the group's desired capacity is reduced by one.
+	// Pass true when scaling down intentionally; pass false when removing a stray instance
+	// so that the group maintains its desired capacity and replaces it automatically.
+	// GCP and Azure implementations ignore this parameter — their platforms adjust
+	// capacity automatically regardless.
+	KillInstance(ctx context.Context, instanceID string, decrementCapacity bool) (err error)
 	ScaleUpASG(ctx context.Context, desiredCapacity int) (err error)
 	InstanceIdentity(worker *Worker) (groupID GroupID, instanceID InstanceID, err error)
 	Close() error // Release resources when done
@@ -140,7 +142,7 @@ func (s AutoScaler) Scale(ctx context.Context, cfg RuntimeConfig) error {
 			if instanceAge > 10*time.Minute {
 				logger.Warn("instance has no corresponding worker in Spacelift, removing from the ASG")
 
-				if err := s.controller.KillInstance(ctx, instance.ID); err != nil {
+				if err := s.controller.KillInstance(ctx, instance.ID, false); err != nil {
 					logger.Error("could not kill stray instance", "error", err)
 					error_count++
 					continue
@@ -214,7 +216,7 @@ func (s AutoScaler) Scale(ctx context.Context, cfg RuntimeConfig) error {
 			continue
 		}
 
-		if err := s.controller.KillInstance(ctx, string(instanceID)); err != nil {
+		if err := s.controller.KillInstance(ctx, string(instanceID), true); err != nil {
 			logger.Error("could not kill instance", "error", err)
 			error_count++
 			continue

--- a/internal/auto_scaler_test.go
+++ b/internal/auto_scaler_test.go
@@ -140,7 +140,7 @@ func TestAutoScalerScalingDown(t *testing.T) {
 		},
 	}, nil)
 	ctrl.On("DrainWorker", mock.Anything, "1").Return(true, nil)
-	ctrl.On("KillInstance", mock.Anything, "instance").Return(nil)
+	ctrl.On("KillInstance", mock.Anything, "instance", true).Return(nil)
 	err := scaler.Scale(t.Context(), cfg)
 	require.NoError(t, err)
 }
@@ -181,7 +181,7 @@ func TestAutoScalerDetachedNotTerminatedInstances(t *testing.T) {
 			{ID: "instance"},
 		},
 	}, nil)
-	ctrl.On("KillInstance", mock.Anything, "detached").Return(nil)
+	ctrl.On("KillInstance", mock.Anything, "detached", false).Return(nil)
 	output := []internal.Instance{{
 		ID:         "detached",
 		LaunchTime: time.Now().Add(-time.Hour),

--- a/internal/aws_controller.go
+++ b/internal/aws_controller.go
@@ -173,7 +173,7 @@ func (c *AWSController) GetAutoscalingGroup(ctx context.Context) (out *AutoScali
 	return out, nil
 }
 
-func (c *AWSController) KillInstance(ctx context.Context, instanceID string) (err error) {
+func (c *AWSController) KillInstance(ctx context.Context, instanceID string, decrementCapacity bool) (err error) {
 	ctx, span := c.Tracer.Start(ctx, "aws.killinstance")
 	defer span.End()
 
@@ -182,7 +182,7 @@ func (c *AWSController) KillInstance(ctx context.Context, instanceID string) (er
 	_, err = c.Autoscaling.DetachInstances(ctx, &autoscaling.DetachInstancesInput{
 		AutoScalingGroupName:           aws.String(c.AWSAutoscalingGroupName),
 		InstanceIds:                    []string{instanceID},
-		ShouldDecrementDesiredCapacity: aws.Bool(true),
+		ShouldDecrementDesiredCapacity: aws.Bool(decrementCapacity),
 	})
 
 	if err != nil && !strings.Contains(err.Error(), "is not part of Auto Scaling group") {

--- a/internal/aws_controller_test.go
+++ b/internal/aws_controller_test.go
@@ -501,7 +501,7 @@ func TestDrainWorker_WorkerBusy_UndrainCallSucceeds_ReportsNotDrained(t *testing
 
 // KillInstance tests
 
-func TestKillInstance_DetachCallFails_SendsCorrectInput(t *testing.T) {
+func TestKillInstance_DecrementTrue_PassedToDetach(t *testing.T) {
 	const instanceID = "test-instance"
 
 	sut, mockAutoscaling, _, _ := setupController()
@@ -517,12 +517,38 @@ func TestKillInstance_DetachCallFails_SendsCorrectInput(t *testing.T) {
 		mock.Anything,
 	).Return(nil, errors.New("bacon"))
 
-	_ = sut.KillInstance(t.Context(), instanceID)
+	_ = sut.KillInstance(t.Context(), instanceID, true)
 
 	require.NotNil(t, capturedInput)
 	require.Contains(t, capturedInput.InstanceIds, instanceID)
 	require.Equal(t, asgName, *capturedInput.AutoScalingGroupName)
 	require.True(t, *capturedInput.ShouldDecrementDesiredCapacity)
+}
+
+func TestKillInstance_DecrementFalse_PassedToDetach(t *testing.T) {
+	const instanceID = "test-instance"
+
+	sut, mockAutoscaling, mockEC2, _ := setupController()
+
+	var capturedInput *autoscaling.DetachInstancesInput
+	mockAutoscaling.On(
+		"DetachInstances",
+		mock.Anything,
+		mock.MatchedBy(func(in *autoscaling.DetachInstancesInput) bool {
+			capturedInput = in
+			return true
+		}),
+		mock.Anything,
+	).Return(nil, nil)
+
+	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	err := sut.KillInstance(t.Context(), instanceID, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedInput)
+	require.False(t, *capturedInput.ShouldDecrementDesiredCapacity)
 }
 
 func TestKillInstance_DetachCallFails_ReturnsError(t *testing.T) {
@@ -533,7 +559,7 @@ func TestKillInstance_DetachCallFails_ReturnsError(t *testing.T) {
 	mockAutoscaling.On("DetachInstances", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("bacon"))
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, true)
 
 	require.EqualError(t, err, "could not detach instance from autoscaling group: bacon")
 }
@@ -549,7 +575,7 @@ func TestKillInstance_InstanceNotPartOfASG_ReturnsError(t *testing.T) {
 	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("bacon"))
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, true)
 
 	require.EqualError(t, err, "could not terminate detached instance: bacon")
 }
@@ -573,7 +599,7 @@ func TestKillInstance_TerminateCallFails_SendsCorrectInput(t *testing.T) {
 		mock.Anything,
 	).Return(nil, errors.New("bacon"))
 
-	_ = sut.KillInstance(t.Context(), instanceID)
+	_ = sut.KillInstance(t.Context(), instanceID, true)
 
 	require.NotNil(t, capturedInput)
 	require.Contains(t, capturedInput.InstanceIds, instanceID)
@@ -590,7 +616,7 @@ func TestKillInstance_TerminateCallFails_ReturnsError(t *testing.T) {
 	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("bacon"))
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, true)
 
 	require.EqualError(t, err, "could not terminate detached instance: bacon")
 }
@@ -606,7 +632,7 @@ func TestKillInstance_Success_NoError(t *testing.T) {
 	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, true)
 
 	require.NoError(t, err)
 }

--- a/internal/azure_controller.go
+++ b/internal/azure_controller.go
@@ -392,7 +392,7 @@ func (c *AzureController) GetAutoscalingGroup(ctx context.Context) (out *AutoSca
 // KillInstance deletes a VM instance from the Azure VMSS.
 //
 // Unlike AWS ASG, Azure VMSS automatically adjusts capacity when an instance is deleted.
-func (c *AzureController) KillInstance(ctx context.Context, instanceID string) (err error) {
+func (c *AzureController) KillInstance(ctx context.Context, instanceID string, _ bool) (err error) {
 	ctx, span := c.Tracer.Start(ctx, "azure.vmss.deleteVM")
 	defer span.End()
 

--- a/internal/azure_controller_test.go
+++ b/internal/azure_controller_test.go
@@ -452,7 +452,7 @@ func TestAzureKillInstance_DeleteCallFails_SendsCorrectInput(t *testing.T) {
 		}),
 	).Return(errors.New("bacon"))
 
-	_ = sut.KillInstance(t.Context(), instanceID)
+	_ = sut.KillInstance(t.Context(), instanceID, false)
 
 	require.Equal(t, azureResourceGroupName, capturedRG)
 	require.Equal(t, azureVMSSName, capturedVMSS)
@@ -467,7 +467,7 @@ func TestAzureKillInstance_DeleteCallFails_ReturnsError(t *testing.T) {
 	mockCompute.On("DeleteVMScaleSetVM", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(errors.New("bacon"))
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, false)
 
 	require.EqualError(t, err, "could not delete Azure VMSS VM instance: bacon")
 }
@@ -480,7 +480,7 @@ func TestAzureKillInstance_Success_NoError(t *testing.T) {
 	mockCompute.On("DeleteVMScaleSetVM", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, false)
 
 	require.NoError(t, err)
 }

--- a/internal/gcp_controller.go
+++ b/internal/gcp_controller.go
@@ -47,13 +47,13 @@ type GCPController struct {
 	Instances ifaces.GCPInstances // Instance operations (always zonal)
 
 	// Configuration.
-	Project     string
-	Location    string // Zone for zonal IGMs, region for regional IGMs
-	IGMName     string
-	IGMID string // e.g., projects/{project}/zones/{zone}/instanceGroupManagers/{name}
-	IsRegional  bool
-	MinSize     uint
-	MaxSize     uint
+	Project    string
+	Location   string // Zone for zonal IGMs, region for regional IGMs
+	IGMName    string
+	IGMID      string // e.g., projects/{project}/zones/{zone}/instanceGroupManagers/{name}
+	IsRegional bool
+	MinSize    uint
+	MaxSize    uint
 }
 
 // igmID holds parsed components of an IGM resource ID.
@@ -111,13 +111,13 @@ func NewGCPController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 	}
 
 	ctrl := &GCPController{
-		Project:     parsedIGM.Project,
-		Location:    parsedIGM.Location,
-		IGMName:     parsedIGM.Name,
-		IGMID: cfg.GCPIGMID,
-		IsRegional:  parsedIGM.IsRegional,
-		MinSize:     cfg.AutoscalingMinSize,
-		MaxSize:     cfg.AutoscalingMaxSize,
+		Project:    parsedIGM.Project,
+		Location:   parsedIGM.Location,
+		IGMName:    parsedIGM.Name,
+		IGMID:      cfg.GCPIGMID,
+		IsRegional: parsedIGM.IsRegional,
+		MinSize:    cfg.AutoscalingMinSize,
+		MaxSize:    cfg.AutoscalingMaxSize,
 	}
 
 	// Fetch Spacelift API key from Secret Manager (client is only needed during initialization)
@@ -309,7 +309,7 @@ func (c *GCPController) GetAutoscalingGroup(ctx context.Context) (out *AutoScali
 // KillInstance deletes an instance from the GCP IGM.
 //
 // Unlike AWS ASG, GCP IGM automatically adjusts capacity when an instance is deleted.
-func (c *GCPController) KillInstance(ctx context.Context, instanceID string) (err error) {
+func (c *GCPController) KillInstance(ctx context.Context, instanceID string, _ bool) (err error) {
 	ctx, span := c.Tracer.Start(ctx, "gcp.igm.deleteInstance")
 	defer span.End()
 

--- a/internal/gcp_controller_test.go
+++ b/internal/gcp_controller_test.go
@@ -23,7 +23,7 @@ const (
 	gcpZone         = "us-central1-a"
 	gcpRegion       = "us-central1"
 	gcpIGMName      = "my-mig"
-	gcpIGMID  = "projects/my-project/zones/us-central1-a/instanceGroupManagers/my-mig"
+	gcpIGMID        = "projects/my-project/zones/us-central1-a/instanceGroupManagers/my-mig"
 )
 
 // Helper function to create a pointer to a value
@@ -63,7 +63,7 @@ func setupGCPController(t *testing.T, isRegional bool) (*internal.GCPController,
 		Project:    gcpProject,
 		Location:   location,
 		IGMName:    gcpIGMName,
-		IGMID: gcpIGMID,
+		IGMID:      gcpIGMID,
 		IsRegional: isRegional,
 		MinSize:    0,
 		MaxSize:    10,
@@ -407,7 +407,7 @@ func TestGCPKillInstance_DeleteFails_ReturnsError(t *testing.T) {
 	mockCompute.On("DeleteInstance", mock.Anything, gcpProject, gcpZone, gcpIGMName, instanceID).
 		Return(errors.New("delete error"))
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, false)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "could not delete GCP IGM instance")
@@ -421,7 +421,7 @@ func TestGCPKillInstance_Success_NoError(t *testing.T) {
 	mockCompute.On("DeleteInstance", mock.Anything, gcpProject, gcpZone, gcpIGMName, instanceID).
 		Return(nil)
 
-	err := sut.KillInstance(t.Context(), instanceID)
+	err := sut.KillInstance(t.Context(), instanceID, false)
 
 	require.NoError(t, err)
 }
@@ -450,5 +450,3 @@ func TestGCPScaleUpASG_Success_NoError(t *testing.T) {
 
 	require.NoError(t, err)
 }
-
-

--- a/internal/mock_controller_test.go
+++ b/internal/mock_controller_test.go
@@ -185,17 +185,17 @@ func (_m *MockController) InstanceIdentity(worker *internal.Worker) (internal.Gr
 	return r0, r1, r2
 }
 
-// KillInstance provides a mock function with given fields: ctx, instanceID
-func (_m *MockController) KillInstance(ctx context.Context, instanceID string) error {
-	ret := _m.Called(ctx, instanceID)
+// KillInstance provides a mock function with given fields: ctx, instanceID, decrementCapacity
+func (_m *MockController) KillInstance(ctx context.Context, instanceID string, decrementCapacity bool) error {
+	ret := _m.Called(ctx, instanceID, decrementCapacity)
 
 	if len(ret) == 0 {
 		panic("no return value specified for KillInstance")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, instanceID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) error); ok {
+		r0 = rf(ctx, instanceID, decrementCapacity)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
KillInstance called DetachInstances with ShouldDecrementDesiredCapacity= true, which AWS rejects when the ASG is already at min_size. Retry with false so the ASG keeps its desired capacity and replaces the stray with a healthy instance.