### PR TITLE
feat: Base scale-down delay on idle time instead of creation time

### DIFF
--- a/internal/state.go
+++ b/internal/state.go
@@ -108,9 +108,18 @@ func (s *State) ScalableWorkers() []Worker {
 		// Even though the worker might be idle, we will give it some time to pick up more work
 		// if the customer wants
 		if s.cfg.AutoscalingScaleDownDelay != 0 {
-			workerCreationTime := time.Unix(int64(worker.CreatedAt), 0)
-			minimumAliveTime := workerCreationTime.Add(time.Duration(s.cfg.AutoscalingScaleDownDelay) * time.Minute)
-			if !time.Now().After(minimumAliveTime) {
+			// Use availableAt (when worker became idle) if set, otherwise fall back
+			// to createdAt for backward compatibility with workers created before
+			// the backend started tracking availableAt.
+			var idleSince time.Time
+			if worker.AvailableAt != nil {
+				idleSince = time.Unix(int64(*worker.AvailableAt), 0)
+			} else {
+				idleSince = time.Unix(int64(worker.CreatedAt), 0)
+			}
+
+			minimumIdleTime := idleSince.Add(time.Duration(s.cfg.AutoscalingScaleDownDelay) * time.Minute)
+			if !time.Now().After(minimumIdleTime) {
 				continue
 			}
 		}

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -812,6 +812,125 @@ func TestDecide_WaitingForIdleWorkers_NoScaling(t *testing.T) {
 	require.ElementsMatch(t, []string{"autoscaling group exactly at the right size"}, decision.Comments)
 }
 
+func TestScalableWorkers_WithAvailableAt_UsesAvailableAtForIdleTime(t *testing.T) {
+	asg := &internal.AutoScalingGroup{
+		Name:            "asg-name",
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 1,
+	}
+
+	// Worker created 10 minutes ago but became available (idle) just now
+	createdAt := int32(time.Now().Add(-10 * time.Minute).Unix())
+	availableAt := int32(time.Now().Unix()) // just became idle
+
+	workerPool := &internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				ID:          "worker-with-available-at",
+				Busy:        false,
+				CreatedAt:   createdAt,
+				AvailableAt: &availableAt,
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      "asg-name",
+					"instance_id": "i-1",
+				}),
+			},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingScaleDownDelay: 5, // 5 minute delay
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	scalableWorkers := state.ScalableWorkers()
+
+	// Worker should NOT be scalable because it just became available (< 5 min idle)
+	// even though it was created 10 minutes ago
+	require.Empty(t, scalableWorkers, "worker should not be scalable because availableAt is recent")
+}
+
+func TestScalableWorkers_WithAvailableAt_IdleLongEnough_IsScalable(t *testing.T) {
+	asg := &internal.AutoScalingGroup{
+		Name:            "asg-name",
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 1,
+	}
+
+	// Worker became available 10 minutes ago
+	createdAt := int32(time.Now().Add(-30 * time.Minute).Unix())
+	availableAt := int32(time.Now().Add(-10 * time.Minute).Unix())
+
+	workerPool := &internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				ID:          "worker-idle-long-enough",
+				Busy:        false,
+				CreatedAt:   createdAt,
+				AvailableAt: &availableAt,
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      "asg-name",
+					"instance_id": "i-1",
+				}),
+			},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingScaleDownDelay: 5, // 5 minute delay
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	scalableWorkers := state.ScalableWorkers()
+
+	// Worker should be scalable because it's been idle for 10 minutes (> 5 min delay)
+	require.Len(t, scalableWorkers, 1)
+	require.Equal(t, "worker-idle-long-enough", scalableWorkers[0].ID)
+}
+
+func TestScalableWorkers_WithoutAvailableAt_FallsBackToCreatedAt(t *testing.T) {
+	asg := &internal.AutoScalingGroup{
+		Name:            "asg-name",
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 1,
+	}
+
+	// Worker created 10 minutes ago, no availableAt (legacy worker)
+	createdAt := int32(time.Now().Add(-10 * time.Minute).Unix())
+
+	workerPool := &internal.WorkerPool{
+		Workers: []internal.Worker{
+			{
+				ID:          "legacy-worker",
+				Busy:        false,
+				CreatedAt:   createdAt,
+				AvailableAt: nil, // not set - legacy worker
+				Metadata: mustJSON(map[string]any{
+					"asg_id":      "asg-name",
+					"instance_id": "i-1",
+				}),
+			},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingScaleDownDelay: 5, // 5 minute delay
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	scalableWorkers := state.ScalableWorkers()
+
+	// Worker should be scalable because createdAt is 10 minutes ago (> 5 min delay)
+	require.Len(t, scalableWorkers, 1)
+	require.Equal(t, "legacy-worker", scalableWorkers[0].ID)
+}
+
 func nullable[T any](t T) *T {
 	out := t
 	return &out

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -9,11 +9,12 @@ type GroupID string
 type InstanceID string
 
 type Worker struct {
-	ID        string `graphql:"id" json:"id"`
-	Busy      bool   `graphql:"busy" json:"busy"`
-	CreatedAt int32  `graphql:"createdAt" json:"createdAt"`
-	Drained   bool   `graphql:"drained" json:"drained"`
-	Metadata  string `graphql:"metadata" json:"metadata"`
+	ID          string `graphql:"id" json:"id"`
+	Busy        bool   `graphql:"busy" json:"busy"`
+	CreatedAt   int32  `graphql:"createdAt" json:"createdAt"`
+	AvailableAt *int32 `graphql:"availableAt" json:"availableAt"`
+	Drained     bool   `graphql:"drained" json:"drained"`
+	Metadata    string `graphql:"metadata" json:"metadata"`
 }
 
 func (w *Worker) metadata() (map[string]string, error) {


### PR DESCRIPTION

Use the new availableAt field from the Spacelift API to determine when a worker became idle, instead of using createdAt. This prevents killing workers that are actively processing work bursts.

Falls back to createdAt for backward compatibility with workers that don't have availableAt set (created before the backend change).
<img width="2550" height="1339" alt="Screenshot 2026-04-15 at 13 42 38" src="https://github.com/user-attachments/assets/cc215bd7-7e56-4428-880f-ee788b0985d6" />


