### PR TITLE
feat: Add configurable target utilization for scaling headroom

### DIFF
--- a/internal/auto_scaler.go
+++ b/internal/auto_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 )
 
@@ -74,8 +75,14 @@ func (s AutoScaler) Scale(ctx context.Context, cfg RuntimeConfig) error {
 
 	// Sanity check: Detect if ASG desired capacity is unreasonably high.
 	// This can happen during AWS service disruptions when AWS sets incorrect capacity.
-	// Calculate what we'd expect: valid workers + pending runs + generous buffer for scaling headroom
-	expectedMaxCapacity := state.ValidWorkerCount() + int(workerPool.PendingRuns) + cfg.AutoscalingMaxCreate
+	// Calculate what we'd expect: demand adjusted for target utilization + buffer for scaling headroom
+	demand := state.ValidWorkerCount() + int(workerPool.PendingRuns)
+	targetUtilization := cfg.AutoscalingTargetUtilizationPercent
+	if targetUtilization <= 0 || targetUtilization > 100 {
+		targetUtilization = 100
+	}
+	expectedWithHeadroom := int(math.Ceil(float64(demand) * 100.0 / float64(targetUtilization)))
+	expectedMaxCapacity := expectedWithHeadroom + cfg.AutoscalingMaxCreate
 
 	// Only trigger if capacity is SIGNIFICANTLY higher than expected
 	// to avoid false positives during normal scaling operations
@@ -93,8 +100,8 @@ func (s AutoScaler) Scale(ctx context.Context, cfg RuntimeConfig) error {
 			"difference", asg.DesiredCapacity-expectedMaxCapacity,
 		)
 
-		// Reset to a sane value: valid workers + pending runs (capped by max size)
-		saneCapacity := state.ValidWorkerCount() + int(workerPool.PendingRuns)
+		// Reset to a sane value: demand adjusted for target utilization (capped by max size)
+		saneCapacity := expectedWithHeadroom
 		if saneCapacity < asg.MinSize {
 			saneCapacity = asg.MinSize
 		}

--- a/internal/runtime_config.go
+++ b/internal/runtime_config.go
@@ -19,10 +19,11 @@ type RuntimeConfig struct {
 	SpaceliftWorkerPoolID  string `env:"SPACELIFT_WORKER_POOL_ID,notEmpty"`
 
 	// Shared autoscaling fields (used by both platforms)
-	AutoscalingScaleDownDelay      int `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
-	AutoscalingMaxKill             int `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
-	AutoscalingMaxCreate           int `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
-	AutoscalingCapacitySanityCheck int `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
+	AutoscalingScaleDownDelay           int `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
+	AutoscalingMaxKill                  int `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
+	AutoscalingMaxCreate                int `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
+	AutoscalingCapacitySanityCheck      int `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
+	AutoscalingTargetUtilizationPercent int `env:"AUTOSCALING_TARGET_UTILIZATION_PERCENT" envDefault:"100"`
 
 	// AWS-specific fields - use awsEnv tag
 	AutoscalingGroupARN string `awsEnv:"AUTOSCALING_GROUP_ARN,notEmpty"`

--- a/internal/state.go
+++ b/internal/state.go
@@ -98,6 +98,18 @@ func (s *State) ValidWorkerCount() int {
 	return s.validWorkerCount
 }
 
+// BusyWorkerCount returns the number of valid workers that are currently busy.
+// Only workers with valid metadata (in workersByInstanceID) are counted.
+func (s *State) BusyWorkerCount() int {
+	busy := 0
+	for _, w := range s.workersByInstanceID {
+		if w.Busy {
+			busy++
+		}
+	}
+	return busy
+}
+
 // ScalableWorkers returns a list of workers that are not currently busy.
 func (s *State) ScalableWorkers() []Worker {
 	var out []Worker
@@ -174,19 +186,18 @@ func (s *State) Decide(maxCreate, maxKill int) Decision {
 		}
 	}
 
-	scalable := s.ScalableWorkers()
+	// Calculate demand: busy workers + pending runs
+	demand := s.BusyWorkerCount() + int(s.WorkerPool.PendingRuns)
 
-	// Apply target utilization to create headroom. At 90% target, 10 workers
-	// count as 9 effective capacity, prompting scale-up sooner. The result is
-	// floored to favor maintaining headroom: 5 workers at 90% yields 4
-	// effective capacity, not 5.
+	// Apply target utilization to create headroom. At 90% target, 10 demand
+	// requires ceil(10/0.9) = 12 workers to maintain 10% spare capacity.
 	targetUtilization := s.cfg.AutoscalingTargetUtilizationPercent
 	if targetUtilization <= 0 || targetUtilization > 100 {
 		targetUtilization = 100
 	}
-	effectiveScalable := int(math.Floor(float64(len(scalable)) * float64(targetUtilization) / 100.0))
+	desiredTotal := int(math.Ceil(float64(demand) * 100.0 / float64(targetUtilization)))
 
-	difference := int(s.WorkerPool.PendingRuns) - effectiveScalable
+	difference := desiredTotal - s.validWorkerCount
 
 	// Enforce minimum size: if we're below the floor, ensure we scale up
 	// to at least MinSize. AWS ASGs enforce this natively; GCP and Azure
@@ -200,7 +211,20 @@ func (s *State) Decide(maxCreate, maxKill int) Decision {
 	}
 
 	if difference < 0 {
-		return s.determineScaleDown(-difference, maxKill)
+		// Can only scale down workers that are scalable (idle + past scale-down delay)
+		scalable := s.ScalableWorkers()
+		if len(scalable) == 0 {
+			return Decision{
+				ScalingDirection: ScalingDirectionNone,
+				Comments:         []string{"autoscaling group exactly at the right size"},
+			}
+		}
+		// Cap scale-down to the number of actually scalable workers
+		toScaleDown := -difference
+		if toScaleDown > len(scalable) {
+			toScaleDown = len(scalable)
+		}
+		return s.determineScaleDown(toScaleDown, maxKill)
 	}
 
 	return Decision{

--- a/internal/state.go
+++ b/internal/state.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 )
 
@@ -175,7 +176,17 @@ func (s *State) Decide(maxCreate, maxKill int) Decision {
 
 	scalable := s.ScalableWorkers()
 
-	difference := int(s.WorkerPool.PendingRuns) - len(scalable)
+	// Apply target utilization to create headroom. At 90% target, 10 workers
+	// count as 9 effective capacity, prompting scale-up sooner. The result is
+	// floored to favor maintaining headroom: 5 workers at 90% yields 4
+	// effective capacity, not 5.
+	targetUtilization := s.cfg.AutoscalingTargetUtilizationPercent
+	if targetUtilization <= 0 || targetUtilization > 100 {
+		targetUtilization = 100
+	}
+	effectiveScalable := int(math.Floor(float64(len(scalable)) * float64(targetUtilization) / 100.0))
+
+	difference := int(s.WorkerPool.PendingRuns) - effectiveScalable
 
 	// Enforce minimum size: if we're below the floor, ensure we scale up
 	// to at least MinSize. AWS ASGs enforce this natively; GCP and Azure

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -813,25 +813,35 @@ func TestDecide_WaitingForIdleWorkers_NoScaling(t *testing.T) {
 }
 
 // Target Utilization Tests
+//
+// Formula: demand = busy + pending
+//          desiredTotal = ceil(demand * 100 / targetUtilization)
+//          difference = desiredTotal - validWorkerCount
 
-func TestDecide_TargetUtilization90Percent_5Workers4Pending_NoScaling(t *testing.T) {
-	// With 90% target utilization and 5 workers, effective capacity = floor(5 * 0.9) = 4
-	// 4 pending runs means difference = 0 → no scaling (maintains 1 spare worker)
+func TestDecide_TargetUtilization90Percent_ProactiveScaleUp(t *testing.T) {
+	// 8 busy + 2 pending = 10 demand
+	// At 90%: desiredTotal = ceil(10 / 0.9) = 12
+	// difference = 12 - 10 = +2 → scale up by 2
 	const asgName = "asg-name"
 	asg := &internal.AutoScalingGroup{
 		Name:            asgName,
 		MinSize:         0,
-		MaxSize:         10,
-		DesiredCapacity: 5,
+		MaxSize:         20,
+		DesiredCapacity: 10,
 	}
 	workerPool := &internal.WorkerPool{
-		PendingRuns: 4,
+		PendingRuns: 2,
 		Workers: []internal.Worker{
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+			testWorker(asgName, "i-1", busy),
+			testWorker(asgName, "i-2", busy),
+			testWorker(asgName, "i-3", busy),
+			testWorker(asgName, "i-4", busy),
+			testWorker(asgName, "i-5", busy),
+			testWorker(asgName, "i-6", busy),
+			testWorker(asgName, "i-7", busy),
+			testWorker(asgName, "i-8", busy),
+			testWorker(asgName, "i-9"),
+			testWorker(asgName, "i-10"),
 		},
 	}
 	cfg := internal.RuntimeConfig{
@@ -841,29 +851,74 @@ func TestDecide_TargetUtilization90Percent_5Workers4Pending_NoScaling(t *testing
 	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
 	require.NoError(t, err)
 
-	decision := state.Decide(5, 5)
+	decision := state.Decide(10, 10)
+
+	require.Equal(t, internal.ScalingDirectionUp, decision.ScalingDirection)
+	require.Equal(t, 2, decision.ScalingSize)
+}
+
+func TestDecide_TargetUtilization90Percent_AtEquilibrium(t *testing.T) {
+	// 9 busy + 0 pending = 9 demand
+	// At 90%: desiredTotal = ceil(9 / 0.9) = 10
+	// difference = 10 - 10 = 0 → no scaling
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         20,
+		DesiredCapacity: 10,
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 0,
+		Workers: []internal.Worker{
+			testWorker(asgName, "i-1", busy),
+			testWorker(asgName, "i-2", busy),
+			testWorker(asgName, "i-3", busy),
+			testWorker(asgName, "i-4", busy),
+			testWorker(asgName, "i-5", busy),
+			testWorker(asgName, "i-6", busy),
+			testWorker(asgName, "i-7", busy),
+			testWorker(asgName, "i-8", busy),
+			testWorker(asgName, "i-9", busy),
+			testWorker(asgName, "i-10"),
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 90,
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(10, 10)
 
 	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
 }
 
-func TestDecide_TargetUtilization90Percent_5Workers5Pending_ScalesUp(t *testing.T) {
-	// With 90% target utilization and 5 workers, effective capacity = floor(5 * 0.9) = 4
-	// 5 pending runs means difference = 1 → scale up by 1
+func TestDecide_TargetUtilization90Percent_ScaleDown(t *testing.T) {
+	// 8 busy + 0 pending = 8 demand
+	// At 90%: desiredTotal = ceil(8 / 0.9) = 9
+	// difference = 9 - 10 = -1 → scale down by 1
 	const asgName = "asg-name"
 	asg := &internal.AutoScalingGroup{
 		Name:            asgName,
 		MinSize:         0,
-		MaxSize:         10,
-		DesiredCapacity: 5,
+		MaxSize:         20,
+		DesiredCapacity: 10,
 	}
 	workerPool := &internal.WorkerPool{
-		PendingRuns: 5,
+		PendingRuns: 0,
 		Workers: []internal.Worker{
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+			testWorker(asgName, "i-1", busy),
+			testWorker(asgName, "i-2", busy),
+			testWorker(asgName, "i-3", busy),
+			testWorker(asgName, "i-4", busy),
+			testWorker(asgName, "i-5", busy),
+			testWorker(asgName, "i-6", busy),
+			testWorker(asgName, "i-7", busy),
+			testWorker(asgName, "i-8", busy),
+			testWorker(asgName, "i-9"),
+			testWorker(asgName, "i-10"),
 		},
 	}
 	cfg := internal.RuntimeConfig{
@@ -873,15 +928,16 @@ func TestDecide_TargetUtilization90Percent_5Workers5Pending_ScalesUp(t *testing.
 	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
 	require.NoError(t, err)
 
-	decision := state.Decide(5, 5)
+	decision := state.Decide(10, 10)
 
-	require.Equal(t, internal.ScalingDirectionUp, decision.ScalingDirection)
+	require.Equal(t, internal.ScalingDirectionDown, decision.ScalingDirection)
 	require.Equal(t, 1, decision.ScalingSize)
 }
 
 func TestDecide_TargetUtilization100Percent_BackwardCompatible(t *testing.T) {
-	// With 100% (default) target utilization, behavior should be identical to before
-	// 5 workers, 5 pending → difference = 0 → no scaling
+	// 5 busy + 0 pending = 5 demand
+	// At 100%: desiredTotal = ceil(5 / 1.0) = 5
+	// difference = 5 - 5 = 0 → no scaling
 	const asgName = "asg-name"
 	asg := &internal.AutoScalingGroup{
 		Name:            asgName,
@@ -890,13 +946,13 @@ func TestDecide_TargetUtilization100Percent_BackwardCompatible(t *testing.T) {
 		DesiredCapacity: 5,
 	}
 	workerPool := &internal.WorkerPool{
-		PendingRuns: 5,
+		PendingRuns: 0,
 		Workers: []internal.Worker{
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+			testWorker(asgName, "i-1", busy),
+			testWorker(asgName, "i-2", busy),
+			testWorker(asgName, "i-3", busy),
+			testWorker(asgName, "i-4", busy),
+			testWorker(asgName, "i-5", busy),
 		},
 	}
 	cfg := internal.RuntimeConfig{
@@ -911,11 +967,10 @@ func TestDecide_TargetUtilization100Percent_BackwardCompatible(t *testing.T) {
 	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
 }
 
-func TestDecide_TargetUtilization90Percent_ScaleDownMaintainsHeadroom(t *testing.T) {
-	// With 90% target utilization, 10 workers, 9 pending runs
-	// Effective capacity = floor(10 * 0.9) = 9, difference = 9 - 9 = 0 → no scaling
-	// Without headroom (100%): difference = 9 - 10 = -1 → would scale down by 1
-	// This test verifies headroom prevents premature scale-down
+func TestDecide_TargetUtilization90Percent_FullSaturationScalesUp(t *testing.T) {
+	// 10 busy + 2 pending = 12 demand (pool fully saturated with pending work)
+	// At 90%: desiredTotal = ceil(12 / 0.9) = 14
+	// difference = 14 - 10 = +4 → scale up by 4
 	const asgName = "asg-name"
 	asg := &internal.AutoScalingGroup{
 		Name:            asgName,
@@ -924,18 +979,18 @@ func TestDecide_TargetUtilization90Percent_ScaleDownMaintainsHeadroom(t *testing
 		DesiredCapacity: 10,
 	}
 	workerPool := &internal.WorkerPool{
-		PendingRuns: 9,
+		PendingRuns: 2,
 		Workers: []internal.Worker{
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-6"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-7"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-8"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-9"})},
-			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-10"})},
+			testWorker(asgName, "i-1", busy),
+			testWorker(asgName, "i-2", busy),
+			testWorker(asgName, "i-3", busy),
+			testWorker(asgName, "i-4", busy),
+			testWorker(asgName, "i-5", busy),
+			testWorker(asgName, "i-6", busy),
+			testWorker(asgName, "i-7", busy),
+			testWorker(asgName, "i-8", busy),
+			testWorker(asgName, "i-9", busy),
+			testWorker(asgName, "i-10", busy),
 		},
 	}
 	cfg := internal.RuntimeConfig{
@@ -947,7 +1002,90 @@ func TestDecide_TargetUtilization90Percent_ScaleDownMaintainsHeadroom(t *testing
 
 	decision := state.Decide(10, 10)
 
-	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
+	require.Equal(t, internal.ScalingDirectionUp, decision.ScalingDirection)
+	require.Equal(t, 4, decision.ScalingSize)
+}
+
+func TestDecide_TargetUtilization_ZeroDemand_ScalesToZero(t *testing.T) {
+	// 0 busy + 0 pending = 0 demand
+	// At 90%: desiredTotal = ceil(0 / 0.9) = 0
+	// difference = 0 - 2 = -2 → scale down by 2
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         20,
+		DesiredCapacity: 2,
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 0,
+		Workers: []internal.Worker{
+			testWorker(asgName, "i-1"),
+			testWorker(asgName, "i-2"),
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 90,
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(10, 10)
+
+	require.Equal(t, internal.ScalingDirectionDown, decision.ScalingDirection)
+	require.Equal(t, 2, decision.ScalingSize)
+}
+
+func TestDecide_TargetUtilization_WithScaleDownDelay_CapsToScalableWorkers(t *testing.T) {
+	// 5 busy + 0 pending = 5 demand
+	// At 100%: desiredTotal = ceil(5 / 1.0) = 5
+	// difference = 5 - 10 = -5 → wants to scale down 5
+	// BUT only 2 workers are scalable (past delay)
+	// Should only scale down 2, not 5
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         20,
+		DesiredCapacity: 10,
+	}
+
+	now := time.Now()
+	recentlyIdle := int32(now.Add(-2 * time.Minute).Unix()) // 2 min ago - NOT past 5 min delay
+	longIdle := int32(now.Add(-10 * time.Minute).Unix())    // 10 min ago - past 5 min delay
+
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 0,
+		Workers: []internal.Worker{
+			// 5 busy workers
+			testWorker(asgName, "i-1", busy),
+			testWorker(asgName, "i-2", busy),
+			testWorker(asgName, "i-3", busy),
+			testWorker(asgName, "i-4", busy),
+			testWorker(asgName, "i-5", busy),
+			// 3 idle workers NOT past delay (recently became idle)
+			testWorker(asgName, "i-6", availableAt(recentlyIdle)),
+			testWorker(asgName, "i-7", availableAt(recentlyIdle)),
+			testWorker(asgName, "i-8", availableAt(recentlyIdle)),
+			// 2 idle workers PAST delay (scalable)
+			testWorker(asgName, "i-9", availableAt(longIdle)),
+			testWorker(asgName, "i-10", availableAt(longIdle)),
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 100,
+		AutoscalingScaleDownDelay:           5, // 5 minute delay
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(10, 10)
+
+	// Should scale down only 2 (the scalable ones), not 5
+	require.Equal(t, internal.ScalingDirectionDown, decision.ScalingDirection)
+	require.Equal(t, 2, decision.ScalingSize)
 }
 
 func TestScalableWorkers_WithAvailableAt_UsesAvailableAtForIdleTime(t *testing.T) {
@@ -1080,4 +1218,23 @@ func mustJSON(T any) string {
 		panic(err)
 	}
 	return string(out)
+}
+
+// testWorker creates a Worker with the given ASG name and instance ID.
+// Use option functions to set additional fields.
+func testWorker(asgName, instanceID string, opts ...func(*internal.Worker)) internal.Worker {
+	w := internal.Worker{
+		Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": instanceID}),
+	}
+	for _, opt := range opts {
+		opt(&w)
+	}
+	return w
+}
+
+func busy(w *internal.Worker)    { w.Busy = true }
+func drained(w *internal.Worker) { w.Drained = true }
+
+func availableAt(t int32) func(*internal.Worker) {
+	return func(w *internal.Worker) { w.AvailableAt = &t }
 }

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -812,6 +812,144 @@ func TestDecide_WaitingForIdleWorkers_NoScaling(t *testing.T) {
 	require.ElementsMatch(t, []string{"autoscaling group exactly at the right size"}, decision.Comments)
 }
 
+// Target Utilization Tests
+
+func TestDecide_TargetUtilization90Percent_5Workers4Pending_NoScaling(t *testing.T) {
+	// With 90% target utilization and 5 workers, effective capacity = floor(5 * 0.9) = 4
+	// 4 pending runs means difference = 0 → no scaling (maintains 1 spare worker)
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 5,
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 4,
+		Workers: []internal.Worker{
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 90,
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(5, 5)
+
+	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
+}
+
+func TestDecide_TargetUtilization90Percent_5Workers5Pending_ScalesUp(t *testing.T) {
+	// With 90% target utilization and 5 workers, effective capacity = floor(5 * 0.9) = 4
+	// 5 pending runs means difference = 1 → scale up by 1
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 5,
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 5,
+		Workers: []internal.Worker{
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 90,
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(5, 5)
+
+	require.Equal(t, internal.ScalingDirectionUp, decision.ScalingDirection)
+	require.Equal(t, 1, decision.ScalingSize)
+}
+
+func TestDecide_TargetUtilization100Percent_BackwardCompatible(t *testing.T) {
+	// With 100% (default) target utilization, behavior should be identical to before
+	// 5 workers, 5 pending → difference = 0 → no scaling
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         10,
+		DesiredCapacity: 5,
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 5,
+		Workers: []internal.Worker{
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 100,
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(5, 5)
+
+	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
+}
+
+func TestDecide_TargetUtilization90Percent_ScaleDownMaintainsHeadroom(t *testing.T) {
+	// With 90% target utilization, 10 workers, 9 pending runs
+	// Effective capacity = floor(10 * 0.9) = 9, difference = 9 - 9 = 0 → no scaling
+	// Without headroom (100%): difference = 9 - 10 = -1 → would scale down by 1
+	// This test verifies headroom prevents premature scale-down
+	const asgName = "asg-name"
+	asg := &internal.AutoScalingGroup{
+		Name:            asgName,
+		MinSize:         0,
+		MaxSize:         20,
+		DesiredCapacity: 10,
+	}
+	workerPool := &internal.WorkerPool{
+		PendingRuns: 9,
+		Workers: []internal.Worker{
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-1"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-2"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-3"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-4"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-5"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-6"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-7"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-8"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-9"})},
+			{Metadata: mustJSON(map[string]any{"asg_id": asgName, "instance_id": "i-10"})},
+		},
+	}
+	cfg := internal.RuntimeConfig{
+		AutoscalingTargetUtilizationPercent: 90,
+	}
+
+	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
+	require.NoError(t, err)
+
+	decision := state.Decide(10, 10)
+
+	require.Equal(t, internal.ScalingDirectionNone, decision.ScalingDirection)
+}
+
 func TestScalableWorkers_WithAvailableAt_UsesAvailableAtForIdleTime(t *testing.T) {
 	asg := &internal.AutoScalingGroup{
 		Name:            "asg-name",


### PR DESCRIPTION
Adds  configurable target utilization for scaling headroom. 

  - Adds `AUTOSCALING_TARGET_UTILIZATION_PERCENT` env var (default: 100)
  - At values below 100%, the autoscaler maintains spare capacity by scaling up sooner and resisting scale-down
  - Example: 90% target with 10 workers treats effective capacity as 9, triggering scale-up when pending runs exceed 9