### PR TITLE
feat: Add backward compatibility for availableAt field

### DIFF
--- a/internal/aws_controller.go
+++ b/internal/aws_controller.go
@@ -67,6 +67,7 @@ func NewAWSController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 		Controller: Controller{
 			Spacelift:             spaceliftClient,
 			SpaceliftWorkerPoolID: cfg.SpaceliftWorkerPoolID,
+			UseAvailableAt:        cfg.AutoscalingUseAvailableAt,
 			Tracer:                otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
 		},
 		Autoscaling:             autoscaling.NewFromConfig(awsConfig),

--- a/internal/aws_controller.go
+++ b/internal/aws_controller.go
@@ -65,10 +65,10 @@ func NewAWSController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 
 	return &AWSController{
 		Controller: Controller{
-			Spacelift:             spaceliftClient,
-			SpaceliftWorkerPoolID: cfg.SpaceliftWorkerPoolID,
-			UseAvailableAt:        cfg.AutoscalingUseAvailableAt,
-			Tracer:                otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
+			Spacelift:                 spaceliftClient,
+			SpaceliftWorkerPoolID:     cfg.SpaceliftWorkerPoolID,
+			ScaleDownDelayUseIdleTime: cfg.AutoscalingScaleDownDelayUseIdleTime,
+			Tracer:                    otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
 		},
 		Autoscaling:             autoscaling.NewFromConfig(awsConfig),
 		EC2:                     ec2.NewFromConfig(awsConfig),

--- a/internal/aws_controller_test.go
+++ b/internal/aws_controller_test.go
@@ -37,10 +37,10 @@ func setupController() (*internal.AWSController, *ifaces.MockAutoscaling, *iface
 
 	controller := &internal.AWSController{
 		Controller: internal.Controller{
-			Spacelift:             mockSpacelift,
-			SpaceliftWorkerPoolID: workerPoolID,
-			UseAvailableAt:        true,
-			Tracer:                tp.Tracer("unittest"),
+			Spacelift:                 mockSpacelift,
+			SpaceliftWorkerPoolID:     workerPoolID,
+			ScaleDownDelayUseIdleTime: true,
+			Tracer:                    tp.Tracer("unittest"),
 		},
 		Autoscaling:             mockAutoscaling,
 		EC2:                     mockEC2,
@@ -315,7 +315,7 @@ func TestGetWorkerPool_WorkerPoolFound_ReturnsSortedAndFilteredWorkers(t *testin
 
 func TestGetWorkerPool_LegacyMode_UsesWorkerPoolDetailsLegacy(t *testing.T) {
 	sut, _, _, mockSpacelift := setupController()
-	sut.UseAvailableAt = false
+	sut.ScaleDownDelayUseIdleTime = false
 
 	mockSpacelift.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {

--- a/internal/aws_controller_test.go
+++ b/internal/aws_controller_test.go
@@ -39,6 +39,7 @@ func setupController() (*internal.AWSController, *ifaces.MockAutoscaling, *iface
 		Controller: internal.Controller{
 			Spacelift:             mockSpacelift,
 			SpaceliftWorkerPoolID: workerPoolID,
+			UseAvailableAt:        true,
 			Tracer:                tp.Tracer("unittest"),
 		},
 		Autoscaling:             mockAutoscaling,
@@ -310,6 +311,33 @@ func TestGetWorkerPool_WorkerPoolFound_ReturnsSortedAndFilteredWorkers(t *testin
 	require.Len(t, workerPool.Workers, 2)
 	require.Equal(t, "older", workerPool.Workers[0].ID)
 	require.Equal(t, "newer", workerPool.Workers[1].ID)
+}
+
+func TestGetWorkerPool_LegacyMode_UsesWorkerPoolDetailsLegacy(t *testing.T) {
+	sut, _, _, mockSpacelift := setupController()
+	sut.UseAvailableAt = false
+
+	mockSpacelift.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			details := args.Get(1).(*internal.WorkerPoolDetailsLegacy)
+			details.Pool = &internal.WorkerPoolLegacy{
+				PendingRuns: 5,
+				Workers: []internal.WorkerLegacy{
+					{ID: "worker1", CreatedAt: 100, Busy: true, Drained: false},
+					{ID: "worker2", CreatedAt: 200, Busy: false, Drained: false},
+				},
+			}
+		}).Return(nil)
+
+	workerPool, err := sut.GetWorkerPool(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, workerPool)
+	require.Equal(t, int32(5), workerPool.PendingRuns)
+	require.Len(t, workerPool.Workers, 2)
+	require.Equal(t, "worker1", workerPool.Workers[0].ID)
+	require.Nil(t, workerPool.Workers[0].AvailableAt, "AvailableAt should be nil in legacy mode")
+	require.Nil(t, workerPool.Workers[1].AvailableAt, "AvailableAt should be nil in legacy mode")
 }
 
 // DrainWorker tests

--- a/internal/azure_controller.go
+++ b/internal/azure_controller.go
@@ -265,6 +265,7 @@ func NewAzureController(ctx context.Context, cfg *RuntimeConfig) (ControllerInte
 		Controller: Controller{
 			Spacelift:             spaceliftClient,
 			SpaceliftWorkerPoolID: cfg.SpaceliftWorkerPoolID,
+			UseAvailableAt:        cfg.AutoscalingUseAvailableAt,
 			Tracer:                otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
 		},
 		Compute:                computeClient,

--- a/internal/azure_controller.go
+++ b/internal/azure_controller.go
@@ -263,10 +263,10 @@ func NewAzureController(ctx context.Context, cfg *RuntimeConfig) (ControllerInte
 
 	return &AzureController{
 		Controller: Controller{
-			Spacelift:             spaceliftClient,
-			SpaceliftWorkerPoolID: cfg.SpaceliftWorkerPoolID,
-			UseAvailableAt:        cfg.AutoscalingUseAvailableAt,
-			Tracer:                otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
+			Spacelift:                 spaceliftClient,
+			SpaceliftWorkerPoolID:     cfg.SpaceliftWorkerPoolID,
+			ScaleDownDelayUseIdleTime: cfg.AutoscalingScaleDownDelayUseIdleTime,
+			Tracer:                    otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
 		},
 		Compute:                computeClient,
 		KeyVault:               keyVaultClient,

--- a/internal/azure_controller_test.go
+++ b/internal/azure_controller_test.go
@@ -85,6 +85,7 @@ func setupAzureController() (*internal.AzureController, *MockAzureCompute, *Mock
 		Controller: internal.Controller{
 			Spacelift:             mockSpacelift,
 			SpaceliftWorkerPoolID: workerPoolID,
+			UseAvailableAt:        true,
 			Tracer:                tp.Tracer("unittest"),
 		},
 		Compute:                mockCompute,

--- a/internal/azure_controller_test.go
+++ b/internal/azure_controller_test.go
@@ -83,10 +83,10 @@ func setupAzureController() (*internal.AzureController, *MockAzureCompute, *Mock
 
 	controller := &internal.AzureController{
 		Controller: internal.Controller{
-			Spacelift:             mockSpacelift,
-			SpaceliftWorkerPoolID: workerPoolID,
-			UseAvailableAt:        true,
-			Tracer:                tp.Tracer("unittest"),
+			Spacelift:                 mockSpacelift,
+			SpaceliftWorkerPoolID:     workerPoolID,
+			ScaleDownDelayUseIdleTime: true,
+			Tracer:                    tp.Tracer("unittest"),
 		},
 		Compute:                mockCompute,
 		KeyVault:               mockKeyVault,

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -26,8 +26,8 @@ type Controller struct {
 	Spacelift ifaces.Spacelift
 
 	// Configuration.
-	SpaceliftWorkerPoolID string
-	UseAvailableAt        bool
+	SpaceliftWorkerPoolID     string
+	ScaleDownDelayUseIdleTime bool
 
 	// Telemetry.
 	Tracer trace.Tracer
@@ -57,7 +57,7 @@ func (c *Controller) GetWorkerPool(ctx context.Context) (out *WorkerPool, err er
 	ctx, span := c.Tracer.Start(ctx, "spacelift.workerpool.get")
 	defer span.End()
 
-	if c.UseAvailableAt {
+	if c.ScaleDownDelayUseIdleTime {
 		out, err = c.getWorkerPoolWithAvailableAt(ctx)
 	} else {
 		out, err = c.getWorkerPoolLegacy(ctx)

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -27,6 +27,7 @@ type Controller struct {
 
 	// Configuration.
 	SpaceliftWorkerPoolID string
+	UseAvailableAt        bool
 
 	// Telemetry.
 	Tracer trace.Tracer
@@ -56,39 +57,87 @@ func (c *Controller) GetWorkerPool(ctx context.Context) (out *WorkerPool, err er
 	ctx, span := c.Tracer.Start(ctx, "spacelift.workerpool.get")
 	defer span.End()
 
+	if c.UseAvailableAt {
+		out, err = c.getWorkerPoolWithAvailableAt(ctx)
+	} else {
+		out, err = c.getWorkerPoolLegacy(ctx)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	span.SetAttributes(
+		attribute.Int("workers", len(out.Workers)),
+		attribute.Int("pending_runs", int(out.PendingRuns)),
+	)
+
+	return out, nil
+}
+
+// getWorkerPoolWithAvailableAt queries the worker pool including the availableAt field.
+func (c *Controller) getWorkerPoolWithAvailableAt(ctx context.Context) (*WorkerPool, error) {
 	var wpDetails WorkerPoolDetails
 
-	if err = c.Spacelift.Query(ctx, &wpDetails, map[string]any{"workerPool": c.SpaceliftWorkerPoolID}); err != nil {
-		err = fmt.Errorf("could not get Spacelift worker pool details: %w", err)
-		return nil, err
+	if err := c.Spacelift.Query(ctx, &wpDetails, map[string]any{"workerPool": c.SpaceliftWorkerPoolID}); err != nil {
+		return nil, fmt.Errorf("could not get Spacelift worker pool details: %w", err)
 	}
 
 	if wpDetails.Pool == nil {
-		err = errors.New("worker pool not found or not accessible")
-		return nil, err
+		return nil, errors.New("worker pool not found or not accessible")
 	}
 
-	worker_index := 0
-	for _, worker := range wpDetails.Pool.Workers {
+	c.filterAndSortWorkers(wpDetails.Pool)
+	return wpDetails.Pool, nil
+}
+
+// getWorkerPoolLegacy queries the worker pool without the availableAt field,
+// for compatibility with older Spacelift backends.
+func (c *Controller) getWorkerPoolLegacy(ctx context.Context) (*WorkerPool, error) {
+	var wpDetails WorkerPoolDetailsLegacy
+
+	if err := c.Spacelift.Query(ctx, &wpDetails, map[string]any{"workerPool": c.SpaceliftWorkerPoolID}); err != nil {
+		return nil, fmt.Errorf("could not get Spacelift worker pool details: %w", err)
+	}
+
+	if wpDetails.Pool == nil {
+		return nil, errors.New("worker pool not found or not accessible")
+	}
+
+	// Convert legacy workers to Worker with nil AvailableAt
+	pool := &WorkerPool{
+		PendingRuns: wpDetails.Pool.PendingRuns,
+		Workers:     make([]Worker, 0, len(wpDetails.Pool.Workers)),
+	}
+	for _, w := range wpDetails.Pool.Workers {
+		pool.Workers = append(pool.Workers, Worker{
+			ID:          w.ID,
+			Busy:        w.Busy,
+			CreatedAt:   w.CreatedAt,
+			AvailableAt: nil,
+			Drained:     w.Drained,
+			Metadata:    w.Metadata,
+		})
+	}
+
+	c.filterAndSortWorkers(pool)
+	return pool, nil
+}
+
+// filterAndSortWorkers removes drained workers and sorts by creation time.
+func (c *Controller) filterAndSortWorkers(pool *WorkerPool) {
+	idx := 0
+	for _, worker := range pool.Workers {
 		if !worker.Drained {
-			wpDetails.Pool.Workers[worker_index] = worker
-			worker_index++
+			pool.Workers[idx] = worker
+			idx++
 		}
 	}
-	wpDetails.Pool.Workers = wpDetails.Pool.Workers[:worker_index]
+	pool.Workers = pool.Workers[:idx]
 
-	sort.Slice(wpDetails.Pool.Workers, func(i, j int) bool {
-		return wpDetails.Pool.Workers[i].CreatedAt < wpDetails.Pool.Workers[j].CreatedAt
+	sort.Slice(pool.Workers, func(i, j int) bool {
+		return pool.Workers[i].CreatedAt < pool.Workers[j].CreatedAt
 	})
-
-	span.SetAttributes(
-		attribute.Int("workers", len(wpDetails.Pool.Workers)),
-		attribute.Int("pending_runs", int(wpDetails.Pool.PendingRuns)),
-	)
-
-	out = wpDetails.Pool
-
-	return out, nil
 }
 
 // Drain worker drains a worker in the Spacelift worker pool.

--- a/internal/gcp_controller.go
+++ b/internal/gcp_controller.go
@@ -144,10 +144,10 @@ func NewGCPController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 	}
 
 	ctrl.Controller = Controller{
-		Spacelift:             spaceliftClient,
-		SpaceliftWorkerPoolID: cfg.SpaceliftWorkerPoolID,
-		UseAvailableAt:        cfg.AutoscalingUseAvailableAt,
-		Tracer:                otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
+		Spacelift:                 spaceliftClient,
+		SpaceliftWorkerPoolID:     cfg.SpaceliftWorkerPoolID,
+		ScaleDownDelayUseIdleTime: cfg.AutoscalingScaleDownDelayUseIdleTime,
+		Tracer:                    otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
 	}
 
 	// Create Instances client (always zonal, regardless of IGM type)

--- a/internal/gcp_controller.go
+++ b/internal/gcp_controller.go
@@ -146,6 +146,7 @@ func NewGCPController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 	ctrl.Controller = Controller{
 		Spacelift:             spaceliftClient,
 		SpaceliftWorkerPoolID: cfg.SpaceliftWorkerPoolID,
+		UseAvailableAt:        cfg.AutoscalingUseAvailableAt,
 		Tracer:                otel.Tracer("github.com/spacelift-io/awsautoscalr/internal/controller"),
 	}
 

--- a/internal/gcp_controller_test.go
+++ b/internal/gcp_controller_test.go
@@ -54,10 +54,10 @@ func setupGCPController(t *testing.T, isRegional bool) (*internal.GCPController,
 
 	controller := &internal.GCPController{
 		Controller: internal.Controller{
-			Spacelift:             mockSpacelift,
-			SpaceliftWorkerPoolID: gcpWorkerPoolID,
-			UseAvailableAt:        true,
-			Tracer:                tp.Tracer("unittest"),
+			Spacelift:                 mockSpacelift,
+			SpaceliftWorkerPoolID:     gcpWorkerPoolID,
+			ScaleDownDelayUseIdleTime: true,
+			Tracer:                    tp.Tracer("unittest"),
 		},
 		Compute:    mockCompute,
 		Instances:  mockInstances,

--- a/internal/gcp_controller_test.go
+++ b/internal/gcp_controller_test.go
@@ -56,6 +56,7 @@ func setupGCPController(t *testing.T, isRegional bool) (*internal.GCPController,
 		Controller: internal.Controller{
 			Spacelift:             mockSpacelift,
 			SpaceliftWorkerPoolID: gcpWorkerPoolID,
+			UseAvailableAt:        true,
 			Tracer:                tp.Tracer("unittest"),
 		},
 		Compute:    mockCompute,

--- a/internal/runtime_config.go
+++ b/internal/runtime_config.go
@@ -19,11 +19,12 @@ type RuntimeConfig struct {
 	SpaceliftWorkerPoolID  string `env:"SPACELIFT_WORKER_POOL_ID,notEmpty"`
 
 	// Shared autoscaling fields (used by both platforms)
-	AutoscalingScaleDownDelay           int `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
-	AutoscalingMaxKill                  int `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
-	AutoscalingMaxCreate                int `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
-	AutoscalingCapacitySanityCheck      int `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
-	AutoscalingTargetUtilizationPercent int `env:"AUTOSCALING_TARGET_UTILIZATION_PERCENT" envDefault:"100"`
+	AutoscalingScaleDownDelay           int  `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
+	AutoscalingMaxKill                  int  `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
+	AutoscalingMaxCreate                int  `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
+	AutoscalingCapacitySanityCheck      int  `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
+	AutoscalingTargetUtilizationPercent int  `env:"AUTOSCALING_TARGET_UTILIZATION_PERCENT" envDefault:"100"`
+	AutoscalingUseAvailableAt           bool `env:"AUTOSCALING_USE_AVAILABLE_AT" envDefault:"false"`
 
 	// AWS-specific fields - use awsEnv tag
 	AutoscalingGroupARN string `awsEnv:"AUTOSCALING_GROUP_ARN,notEmpty"`

--- a/internal/runtime_config.go
+++ b/internal/runtime_config.go
@@ -19,12 +19,12 @@ type RuntimeConfig struct {
 	SpaceliftWorkerPoolID  string `env:"SPACELIFT_WORKER_POOL_ID,notEmpty"`
 
 	// Shared autoscaling fields (used by both platforms)
-	AutoscalingScaleDownDelay           int  `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
-	AutoscalingMaxKill                  int  `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
-	AutoscalingMaxCreate                int  `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
-	AutoscalingCapacitySanityCheck      int  `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
-	AutoscalingTargetUtilizationPercent int  `env:"AUTOSCALING_TARGET_UTILIZATION_PERCENT" envDefault:"100"`
-	AutoscalingUseAvailableAt           bool `env:"AUTOSCALING_USE_AVAILABLE_AT" envDefault:"false"`
+	AutoscalingScaleDownDelay            int  `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`
+	AutoscalingMaxKill                   int  `env:"AUTOSCALING_MAX_KILL" envDefault:"1"`
+	AutoscalingMaxCreate                 int  `env:"AUTOSCALING_MAX_CREATE" envDefault:"1"`
+	AutoscalingCapacitySanityCheck       int  `env:"AUTOSCALING_CAPACITY_SANITY_CHECK" envDefault:"10"`
+	AutoscalingTargetUtilizationPercent  int  `env:"AUTOSCALING_TARGET_UTILIZATION_PERCENT" envDefault:"100"`
+	AutoscalingScaleDownDelayUseIdleTime bool `env:"AUTOSCALING_SCALE_DOWN_DELAY_USE_IDLE_TIME" envDefault:"false"`
 
 	// AWS-specific fields - use awsEnv tag
 	AutoscalingGroupARN string `awsEnv:"AUTOSCALING_GROUP_ARN,notEmpty"`

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -17,6 +17,16 @@ type Worker struct {
 	Metadata    string `graphql:"metadata" json:"metadata"`
 }
 
+// WorkerLegacy is used when querying backends that don't support availableAt.
+// This allows the autoscaler to work with older Spacelift versions.
+type WorkerLegacy struct {
+	ID        string `graphql:"id" json:"id"`
+	Busy      bool   `graphql:"busy" json:"busy"`
+	CreatedAt int32  `graphql:"createdAt" json:"createdAt"`
+	Drained   bool   `graphql:"drained" json:"drained"`
+	Metadata  string `graphql:"metadata" json:"metadata"`
+}
+
 func (w *Worker) metadata() (map[string]string, error) {
 	out := make(map[string]string)
 

--- a/internal/worker_pool_details.go
+++ b/internal/worker_pool_details.go
@@ -8,3 +8,14 @@ type WorkerPool struct {
 type WorkerPoolDetails struct {
 	Pool *WorkerPool `graphql:"workerPool(id: $workerPool)"`
 }
+
+// WorkerPoolLegacy is used when querying backends that don't support availableAt.
+type WorkerPoolLegacy struct {
+	PendingRuns int32          `graphql:"pendingRuns" json:"pendingRuns"`
+	Workers     []WorkerLegacy `graphql:"workers" json:"workers"`
+}
+
+// WorkerPoolDetailsLegacy is used when querying backends that don't support availableAt.
+type WorkerPoolDetailsLegacy struct {
+	Pool *WorkerPoolLegacy `graphql:"workerPool(id: $workerPool)"`
+}


### PR DESCRIPTION


- Adds `AUTOSCALING_USE_AVAILABLE_AT` env var (default: `false`) to opt-in to the `availableAt` field
- When disabled, queries use legacy structs without `availableAt` for compatibility with older backends
- When enabled, queries include `availableAt` for idle-time based scale-down protection