### PR TITLE
chore: make solutions engineering the owners of this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @spacelift-io/sirius
+* @spacelift-io/solutions-engineering


### PR DESCRIPTION
After discussing it internally we've decided it makes sense for the solutions engineering team to take ownership of this repo. They already own the worker pool Terraform modules for AWS, Azure and GCP that pull this autoscaler in.