### PR TITLE
feat: Add SPACELIFT_CA_BUNDLE env var for private CA support

### DIFF
--- a/internal/aws_controller.go
+++ b/internal/aws_controller.go
@@ -53,7 +53,7 @@ func NewAWSController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 		return nil, errors.New("could not find Spacelift API key secret value in SSM")
 	}
 
-	spaceliftClient, err := newSpaceliftClient(ctx, cfg.SpaceliftAPIEndpoint, cfg.SpaceliftAPIKeyID, *output.Parameter.Value)
+	spaceliftClient, err := newSpaceliftClient(ctx, cfg.SpaceliftAPIEndpoint, cfg.SpaceliftAPIKeyID, *output.Parameter.Value, cfg.SpaceliftCABundle)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/azure_controller.go
+++ b/internal/azure_controller.go
@@ -250,7 +250,7 @@ func NewAzureController(ctx context.Context, cfg *RuntimeConfig) (ControllerInte
 		return nil, errors.New("could not find Spacelift API key secret value in Key Vault")
 	}
 
-	spaceliftClient, err := newSpaceliftClient(ctx, cfg.SpaceliftAPIEndpoint, cfg.SpaceliftAPIKeyID, *secret.Value)
+	spaceliftClient, err := newSpaceliftClient(ctx, cfg.SpaceliftAPIEndpoint, cfg.SpaceliftAPIKeyID, *secret.Value, cfg.SpaceliftCABundle)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -2,6 +2,9 @@ package internal
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -33,10 +36,30 @@ type Controller struct {
 	Tracer trace.Tracer
 }
 
-func newSpaceliftClient(ctx context.Context, endpoint, keyID, keySecret string) (ifaces.Spacelift, error) {
+func newSpaceliftClient(ctx context.Context, endpoint, keyID, keySecret, caBundle string) (ifaces.Spacelift, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if caBundle != "" {
+		pemBytes, err := base64.StdEncoding.DecodeString(caBundle)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode SPACELIFT_CA_BUNDLE: %w", err)
+		}
+
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			certPool = x509.NewCertPool()
+		}
+
+		if !certPool.AppendCertsFromPEM(pemBytes) {
+			return nil, errors.New("SPACELIFT_CA_BUNDLE contained no valid PEM certificates")
+		}
+
+		transport.TLSClientConfig = &tls.Config{RootCAs: certPool}
+	}
+
 	httpClient := &http.Client{
 		Transport: otelhttp.NewTransport(
-			http.DefaultTransport,
+			transport,
 			otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 				return r.Host
 			}),
@@ -44,7 +67,6 @@ func newSpaceliftClient(ctx context.Context, endpoint, keyID, keySecret string) 
 	}
 
 	slSession, err := session.FromAPIKey(ctx, httpClient)(endpoint, keyID, keySecret)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not create Spacelift session: %w", err)
 	}

--- a/internal/gcp_controller.go
+++ b/internal/gcp_controller.go
@@ -138,7 +138,7 @@ func NewGCPController(ctx context.Context, cfg *RuntimeConfig) (ControllerInterf
 		return nil, errors.Join(errors.New("could not find Spacelift API key secret value in Secret Manager"), ctrl.Close())
 	}
 
-	spaceliftClient, err := newSpaceliftClient(ctx, cfg.SpaceliftAPIEndpoint, cfg.SpaceliftAPIKeyID, string(secret.Payload.Data))
+	spaceliftClient, err := newSpaceliftClient(ctx, cfg.SpaceliftAPIEndpoint, cfg.SpaceliftAPIKeyID, string(secret.Payload.Data), cfg.SpaceliftCABundle)
 	if err != nil {
 		return nil, errors.Join(err, ctrl.Close())
 	}

--- a/internal/runtime_config.go
+++ b/internal/runtime_config.go
@@ -17,6 +17,7 @@ type RuntimeConfig struct {
 	SpaceliftAPISecretName string `env:"SPACELIFT_API_KEY_SECRET_NAME,notEmpty"`
 	SpaceliftAPIEndpoint   string `env:"SPACELIFT_API_KEY_ENDPOINT,notEmpty"`
 	SpaceliftWorkerPoolID  string `env:"SPACELIFT_WORKER_POOL_ID,notEmpty"`
+	SpaceliftCABundle      string `env:"SPACELIFT_CA_BUNDLE"`
 
 	// Shared autoscaling fields (used by both platforms)
 	AutoscalingScaleDownDelay            int  `env:"AUTOSCALING_SCALE_DOWN_DELAY" envDefault:"0"`


### PR DESCRIPTION
## What
Adds a new optional `SPACELIFT_CA_BUNDLE` environment variable that accepts a base64-encoded PEM certificate bundle for a private/internal CA.
## Why
Users running Spacelift behind a private CA (e.g. in air-gapped environments or with internal TLS termination) couldn't connect the autoscaler because Go's default HTTP transport only trusts the system cert pool.
## How it works
- `SPACELIFT_CA_BUNDLE` is optional (no `notEmpty`), available on all platforms (AWS, GCP, Azure)
- When set, the value is base64-decoded to PEM bytes, appended to the system cert pool (falling back to an empty pool if unavailable), and used as `RootCAs` on a cloned `http.DefaultTransport`
- When unset, behaviour is identical to before
## Usage
# Linux
SPACELIFT_CA_BUNDLE=$(base64 -w0 /path/to/ca.pem)
# macOS
SPACELIFT_CA_BUNDLE=$(base64 -i /path/to/ca.pem)
## Reviewer notes
- Only the Spacelift API HTTP client is affected; cloud provider SDK clients (AWS SSM, GCP Secret Manager, Azure Key Vault) use their own credential chains and are unaffected
- Errors are surfaced early (at controller construction time) with clear messages for both invalid base64 and invalid PEM