### PR TITLE
feat: add Support: Get Info + Comment workflows (triage board)

### DIFF
--- a/.github/workflows/support-comment.yaml
+++ b/.github/workflows/support-comment.yaml
@@ -1,0 +1,18 @@
+name: "Support: Comment"
+
+on:
+  workflow_run:
+    workflows: [ "Support: Get Info" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    uses: spacelift-io/.github/.github/workflows/support-comment.yaml@main
+    secrets:
+      slack_webhook_url: ${{ secrets.SUPPORT_SLACK_WEBHOOK_URL }}
+      triage_project_token: ${{ secrets.SUPPORT_TRIAGE_PROJECT_TOKEN }}

--- a/.github/workflows/support-get-info.yaml
+++ b/.github/workflows/support-get-info.yaml
@@ -1,0 +1,14 @@
+name: "Support: Get Info"
+
+on:
+  issues:
+    types: [ opened ]
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  get-info:
+    uses: spacelift-io/.github/.github/workflows/support-get-info.yaml@main


### PR DESCRIPTION
## Summary

Onboard this repo to the shared Spacelift support/triage system. Previously this repo had no support workflows; this PR adds both halves of the two-step flow.

When a new issue or PR is opened:
- it is added to the [Spacelift Triage Board](https://github.com/orgs/spacelift-solutions/projects/3) (everyone), and
- external authors additionally get a "thanks, we've got it" comment and a Slack notification.

See spacelift-io/.github#1 for the reusable-workflow implementation.

## Changes

1. **`.github/workflows/support-get-info.yaml`** (new): runs on `issues`/`pull_request` opened; calls the `support-get-info` reusable workflow (untrusted, no secrets).
2. **`.github/workflows/support-comment.yaml`** (new): runs on completion of the above via `workflow_run`; calls `support-comment`, passing `slack_webhook_url` and `triage_project_token`.

## Required secrets

- `SUPPORT_TRIAGE_PROJECT_TOKEN` — set on this repo.
- `SUPPORT_SLACK_WEBHOOK_URL` — must be available to this repo (org secret or repo secret) for the Slack step; verify before relying on notifications.