### PR TITLE
fix: terminate instances atomically via TerminateInstanceInAutoScalingGroup

### DIFF
--- a/internal/auto_scaler_test.go
+++ b/internal/auto_scaler_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -145,55 +144,6 @@ func TestAutoScalerScalingDown(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAutoScalerDetachedNotTerminatedInstances(t *testing.T) {
-	var buf bytes.Buffer
-	h := slog.NewTextHandler(&buf, nil)
-
-	cfg := internal.RuntimeConfig{}
-
-	ctrl := new(MockController)
-	defer ctrl.AssertExpectations(t)
-
-	scaler := internal.NewAutoScaler(ctrl, slog.New(h))
-
-	setupInstanceIdentityMock(ctrl)
-
-	ctrl.On("GetWorkerPool", mock.Anything).Return(&internal.WorkerPool{
-		Workers: []internal.Worker{
-			{
-				ID:       "1",
-				Metadata: `{"asg_id": "group", "instance_id": "instance"}`,
-			},
-			{
-				ID:       "2",
-				Drained:  true,
-				Metadata: `{"asg_id": "group", "instance_id": "detached"}`,
-			},
-		},
-		PendingRuns: 2,
-	}, nil)
-	ctrl.On("GetAutoscalingGroup", mock.Anything).Return(&internal.AutoScalingGroup{
-		Name:            "group",
-		MinSize:         1,
-		MaxSize:         3,
-		DesiredCapacity: 2,
-		Instances: []internal.Instance{
-			{ID: "instance"},
-		},
-	}, nil)
-	ctrl.On("KillInstance", mock.Anything, "detached", false).Return(nil)
-	output := []internal.Instance{{
-		ID:         "detached",
-		LaunchTime: time.Now().Add(-time.Hour),
-	}}
-	ctrl.On(
-		"DescribeInstances",
-		mock.Anything,
-		[]string{"detached"},
-	).Return(output, nil)
-	err := scaler.Scale(t.Context(), cfg)
-	require.NoError(t, err)
-}
 func TestAutoScalerDesiredCapacitySanityCheck(t *testing.T) {
 	var buf bytes.Buffer
 	h := slog.NewTextHandler(&buf, nil)

--- a/internal/aws_controller.go
+++ b/internal/aws_controller.go
@@ -202,23 +202,13 @@ func (c *AWSController) KillInstance(ctx context.Context, instanceID string, dec
 
 	span.SetAttributes(attribute.String("instance_id", instanceID))
 
-	_, err = c.Autoscaling.DetachInstances(ctx, &autoscaling.DetachInstancesInput{
-		AutoScalingGroupName:           aws.String(c.AWSAutoscalingGroupName),
-		InstanceIds:                    []string{instanceID},
+	_, err = c.Autoscaling.TerminateInstanceInAutoScalingGroup(ctx, &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String(instanceID),
 		ShouldDecrementDesiredCapacity: aws.Bool(decrementCapacity),
 	})
 
-	if err != nil && !strings.Contains(err.Error(), "is not part of Auto Scaling group") {
-		err = fmt.Errorf("could not detach instance from autoscaling group: %v", err)
-		return err
-	}
-
-	_, err = c.EC2.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
-		InstanceIds: []string{instanceID},
-	})
-
 	if err != nil {
-		err = fmt.Errorf("could not terminate detached instance: %v", err)
+		err = fmt.Errorf("could not terminate instance in autoscaling group: %w", err)
 		return err
 	}
 

--- a/internal/aws_controller_test.go
+++ b/internal/aws_controller_test.go
@@ -529,135 +529,73 @@ func TestDrainWorker_WorkerBusy_UndrainCallSucceeds_ReportsNotDrained(t *testing
 
 // KillInstance tests
 
-func TestKillInstance_DecrementTrue_PassedToDetach(t *testing.T) {
+func TestKillInstance_DecrementTrue_PassedToTerminate(t *testing.T) {
 	const instanceID = "test-instance"
 
 	sut, mockAutoscaling, _, _ := setupController()
 
-	var capturedInput *autoscaling.DetachInstancesInput
+	var capturedInput *autoscaling.TerminateInstanceInAutoScalingGroupInput
 	mockAutoscaling.On(
-		"DetachInstances",
+		"TerminateInstanceInAutoScalingGroup",
 		mock.Anything,
-		mock.MatchedBy(func(in *autoscaling.DetachInstancesInput) bool {
-			capturedInput = in
-			return true
-		}),
-		mock.Anything,
-	).Return(nil, errors.New("bacon"))
-
-	_ = sut.KillInstance(t.Context(), instanceID, true)
-
-	require.NotNil(t, capturedInput)
-	require.Contains(t, capturedInput.InstanceIds, instanceID)
-	require.Equal(t, asgName, *capturedInput.AutoScalingGroupName)
-	require.True(t, *capturedInput.ShouldDecrementDesiredCapacity)
-}
-
-func TestKillInstance_DecrementFalse_PassedToDetach(t *testing.T) {
-	const instanceID = "test-instance"
-
-	sut, mockAutoscaling, mockEC2, _ := setupController()
-
-	var capturedInput *autoscaling.DetachInstancesInput
-	mockAutoscaling.On(
-		"DetachInstances",
-		mock.Anything,
-		mock.MatchedBy(func(in *autoscaling.DetachInstancesInput) bool {
+		mock.MatchedBy(func(in *autoscaling.TerminateInstanceInAutoScalingGroupInput) bool {
 			capturedInput = in
 			return true
 		}),
 		mock.Anything,
 	).Return(nil, nil)
 
-	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil)
+	err := sut.KillInstance(t.Context(), instanceID, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedInput)
+	require.Equal(t, instanceID, *capturedInput.InstanceId)
+	require.True(t, *capturedInput.ShouldDecrementDesiredCapacity)
+}
+
+func TestKillInstance_DecrementFalse_PassedToTerminate(t *testing.T) {
+	const instanceID = "test-instance"
+
+	sut, mockAutoscaling, _, _ := setupController()
+
+	var capturedInput *autoscaling.TerminateInstanceInAutoScalingGroupInput
+	mockAutoscaling.On(
+		"TerminateInstanceInAutoScalingGroup",
+		mock.Anything,
+		mock.MatchedBy(func(in *autoscaling.TerminateInstanceInAutoScalingGroupInput) bool {
+			capturedInput = in
+			return true
+		}),
+		mock.Anything,
+	).Return(nil, nil)
 
 	err := sut.KillInstance(t.Context(), instanceID, false)
 
 	require.NoError(t, err)
 	require.NotNil(t, capturedInput)
+	require.Equal(t, instanceID, *capturedInput.InstanceId)
 	require.False(t, *capturedInput.ShouldDecrementDesiredCapacity)
-}
-
-func TestKillInstance_DetachCallFails_ReturnsError(t *testing.T) {
-	const instanceID = "test-instance"
-
-	sut, mockAutoscaling, _, _ := setupController()
-
-	mockAutoscaling.On("DetachInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, errors.New("bacon"))
-
-	err := sut.KillInstance(t.Context(), instanceID, true)
-
-	require.EqualError(t, err, "could not detach instance from autoscaling group: bacon")
-}
-
-func TestKillInstance_InstanceNotPartOfASG_ReturnsError(t *testing.T) {
-	const instanceID = "test-instance"
-
-	sut, mockAutoscaling, mockEC2, _ := setupController()
-
-	mockAutoscaling.On("DetachInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, errors.New("instance is not part of Auto Scaling group"))
-
-	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, errors.New("bacon"))
-
-	err := sut.KillInstance(t.Context(), instanceID, true)
-
-	require.EqualError(t, err, "could not terminate detached instance: bacon")
-}
-
-func TestKillInstance_TerminateCallFails_SendsCorrectInput(t *testing.T) {
-	const instanceID = "test-instance"
-
-	sut, mockAutoscaling, mockEC2, _ := setupController()
-
-	mockAutoscaling.On("DetachInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil)
-
-	var capturedInput *ec2.TerminateInstancesInput
-	mockEC2.On(
-		"TerminateInstances",
-		mock.Anything,
-		mock.MatchedBy(func(in *ec2.TerminateInstancesInput) bool {
-			capturedInput = in
-			return true
-		}),
-		mock.Anything,
-	).Return(nil, errors.New("bacon"))
-
-	_ = sut.KillInstance(t.Context(), instanceID, true)
-
-	require.NotNil(t, capturedInput)
-	require.Contains(t, capturedInput.InstanceIds, instanceID)
 }
 
 func TestKillInstance_TerminateCallFails_ReturnsError(t *testing.T) {
 	const instanceID = "test-instance"
 
-	sut, mockAutoscaling, mockEC2, _ := setupController()
+	sut, mockAutoscaling, _, _ := setupController()
 
-	mockAutoscaling.On("DetachInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil)
-
-	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
+	mockAutoscaling.On("TerminateInstanceInAutoScalingGroup", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("bacon"))
 
 	err := sut.KillInstance(t.Context(), instanceID, true)
 
-	require.EqualError(t, err, "could not terminate detached instance: bacon")
+	require.EqualError(t, err, "could not terminate instance in autoscaling group: bacon")
 }
 
 func TestKillInstance_Success_NoError(t *testing.T) {
 	const instanceID = "test-instance"
 
-	sut, mockAutoscaling, mockEC2, _ := setupController()
+	sut, mockAutoscaling, _, _ := setupController()
 
-	mockAutoscaling.On("DetachInstances", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil)
-
-	mockEC2.On("TerminateInstances", mock.Anything, mock.Anything, mock.Anything).
+	mockAutoscaling.On("TerminateInstanceInAutoScalingGroup", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	err := sut.KillInstance(t.Context(), instanceID, true)

--- a/internal/ifaces/autoscaling.go
+++ b/internal/ifaces/autoscaling.go
@@ -12,6 +12,6 @@ import (
 //go:generate mockery --inpackage --name Autoscaling --filename mock_autoscaling.go
 type Autoscaling interface {
 	DescribeAutoScalingGroups(context.Context, *autoscaling.DescribeAutoScalingGroupsInput, ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
-	DetachInstances(context.Context, *autoscaling.DetachInstancesInput, ...func(*autoscaling.Options)) (*autoscaling.DetachInstancesOutput, error)
 	SetDesiredCapacity(context.Context, *autoscaling.SetDesiredCapacityInput, ...func(*autoscaling.Options)) (*autoscaling.SetDesiredCapacityOutput, error)
+	TerminateInstanceInAutoScalingGroup(context.Context, *autoscaling.TerminateInstanceInAutoScalingGroupInput, ...func(*autoscaling.Options)) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error)
 }

--- a/internal/ifaces/ec2.go
+++ b/internal/ifaces/ec2.go
@@ -12,5 +12,4 @@ import (
 //go:generate mockery --inpackage --name EC2 --filename mock_ec2.go
 type EC2 interface {
 	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
-	TerminateInstances(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
 }

--- a/internal/ifaces/mock_autoscaling.go
+++ b/internal/ifaces/mock_autoscaling.go
@@ -52,43 +52,6 @@ func (_m *MockAutoscaling) DescribeAutoScalingGroups(_a0 context.Context, _a1 *a
 	return r0, r1
 }
 
-// DetachInstances provides a mock function with given fields: _a0, _a1, _a2
-func (_m *MockAutoscaling) DetachInstances(_a0 context.Context, _a1 *autoscaling.DetachInstancesInput, _a2 ...func(*autoscaling.Options)) (*autoscaling.DetachInstancesOutput, error) {
-	_va := make([]interface{}, len(_a2))
-	for _i := range _a2 {
-		_va[_i] = _a2[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0, _a1)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DetachInstances")
-	}
-
-	var r0 *autoscaling.DetachInstancesOutput
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *autoscaling.DetachInstancesInput, ...func(*autoscaling.Options)) (*autoscaling.DetachInstancesOutput, error)); ok {
-		return rf(_a0, _a1, _a2...)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *autoscaling.DetachInstancesInput, ...func(*autoscaling.Options)) *autoscaling.DetachInstancesOutput); ok {
-		r0 = rf(_a0, _a1, _a2...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*autoscaling.DetachInstancesOutput)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *autoscaling.DetachInstancesInput, ...func(*autoscaling.Options)) error); ok {
-		r1 = rf(_a0, _a1, _a2...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // SetDesiredCapacity provides a mock function with given fields: _a0, _a1, _a2
 func (_m *MockAutoscaling) SetDesiredCapacity(_a0 context.Context, _a1 *autoscaling.SetDesiredCapacityInput, _a2 ...func(*autoscaling.Options)) (*autoscaling.SetDesiredCapacityOutput, error) {
 	_va := make([]interface{}, len(_a2))
@@ -118,6 +81,43 @@ func (_m *MockAutoscaling) SetDesiredCapacity(_a0 context.Context, _a1 *autoscal
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *autoscaling.SetDesiredCapacityInput, ...func(*autoscaling.Options)) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// TerminateInstanceInAutoScalingGroup provides a mock function with given fields: _a0, _a1, _a2
+func (_m *MockAutoscaling) TerminateInstanceInAutoScalingGroup(_a0 context.Context, _a1 *autoscaling.TerminateInstanceInAutoScalingGroupInput, _a2 ...func(*autoscaling.Options)) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TerminateInstanceInAutoScalingGroup")
+	}
+
+	var r0 *autoscaling.TerminateInstanceInAutoScalingGroupOutput
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *autoscaling.TerminateInstanceInAutoScalingGroupInput, ...func(*autoscaling.Options)) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error)); ok {
+		return rf(_a0, _a1, _a2...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *autoscaling.TerminateInstanceInAutoScalingGroupInput, ...func(*autoscaling.Options)) *autoscaling.TerminateInstanceInAutoScalingGroupOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*autoscaling.TerminateInstanceInAutoScalingGroupOutput)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *autoscaling.TerminateInstanceInAutoScalingGroupInput, ...func(*autoscaling.Options)) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)

--- a/internal/ifaces/mock_ec2.go
+++ b/internal/ifaces/mock_ec2.go
@@ -51,43 +51,6 @@ func (_m *MockEC2) DescribeInstances(_a0 context.Context, _a1 *ec2.DescribeInsta
 	return r0, r1
 }
 
-// TerminateInstances provides a mock function with given fields: _a0, _a1, _a2
-func (_m *MockEC2) TerminateInstances(_a0 context.Context, _a1 *ec2.TerminateInstancesInput, _a2 ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
-	_va := make([]interface{}, len(_a2))
-	for _i := range _a2 {
-		_va[_i] = _a2[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0, _a1)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for TerminateInstances")
-	}
-
-	var r0 *ec2.TerminateInstancesOutput
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)); ok {
-		return rf(_a0, _a1, _a2...)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) *ec2.TerminateInstancesOutput); ok {
-		r0 = rf(_a0, _a1, _a2...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ec2.TerminateInstancesOutput)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) error); ok {
-		r1 = rf(_a0, _a1, _a2...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // NewMockEC2 creates a new instance of MockEC2. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockEC2(t interface {

--- a/internal/state.go
+++ b/internal/state.go
@@ -153,28 +153,6 @@ func (s *State) StrayInstances() []string {
 		}
 	}
 
-	res = append(res, s.detachedNotTerminatedInstances()...)
-
-	return res
-}
-
-func (s *State) detachedNotTerminatedInstances() []string {
-	instanceIDs := make(map[InstanceID]struct{})
-	for _, instance := range s.ASG.Instances {
-		instanceIDs[InstanceID(instance.ID)] = struct{}{}
-	}
-
-	var res []string
-	for instanceID, worker := range s.workersByInstanceID {
-		if !worker.Drained {
-			continue
-		}
-		if _, ok := instanceIDs[instanceID]; ok {
-			continue
-		}
-
-		res = append(res, string(instanceID))
-	}
 	return res
 }
 

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -28,47 +28,6 @@ func (awsInstanceIdentifier) InstanceIdentity(worker *internal.Worker) (internal
 
 var testIdentifier = awsInstanceIdentifier{}
 
-func TestState_StrayInstances(t *testing.T) {
-	const asgName = "asg-name"
-	const instanceID = "instance-id"
-	const failedToTerminateInstanceID = "instance-id2"
-	cfg := internal.RuntimeConfig{}
-	asg := &internal.AutoScalingGroup{
-		Name:            asgName,
-		MinSize:         1,
-		MaxSize:         5,
-		DesiredCapacity: 3,
-		Instances: []internal.Instance{
-			{
-				ID: instanceID,
-			},
-		},
-	}
-	workerPool := &internal.WorkerPool{
-		Workers: []internal.Worker{
-			{
-				Metadata: mustJSON(map[string]any{
-					"asg_id":      asgName,
-					"instance_id": instanceID,
-				}),
-			},
-			{
-				Drained: true,
-				Metadata: mustJSON(map[string]any{
-					"asg_id":      asgName,
-					"instance_id": failedToTerminateInstanceID,
-				}),
-			},
-		},
-	}
-
-	state, err := internal.NewState(workerPool, asg, cfg, testLogger(), testIdentifier)
-	require.NoError(t, err)
-
-	strayInstances := state.StrayInstances()
-	require.ElementsMatch(t, []string{failedToTerminateInstanceID}, strayInstances)
-}
-
 func TestNewState_ASGNameNotSet_ReturnsError(t *testing.T) {
 	asg := &internal.AutoScalingGroup{
 		Name:            "",


### PR DESCRIPTION
## What

Replace the autoscaler's detach-then-terminate sequence in `AWSController.KillInstance` with a single atomic `TerminateInstanceInAutoScalingGroup` call.

## Why

Scaling down a worker pool could leave a **zombie instance**: detached from the ASG (desired capacity decremented) but never terminated, with its worker still registered in Spacelift — silently burning money and holding a phantom worker.

Root cause: `KillInstance` made two non-atomic AWS calls — `DetachInstances` then `EC2.TerminateInstances`. In the incident, `DetachInstances` *succeeded server-side* (CloudTrail confirmed the detach + capacity decrement) but the client hit a context deadline waiting for the response, so the code returned an error and never reached the terminate call. Any failure in the gap between the two calls strands an instance in that detached-but-alive state.

`TerminateInstanceInAutoScalingGroup` terminates the instance **and** decrements desired capacity in one operation, so a client-side timeout resolves cleanly: either the instance is terminating (request landed) or it's still a healthy ASG member the next cycle retries. No in-between state.

Because this is an ASG-managed termination, scale-down now also triggers the `EC2_INSTANCE_TERMINATING` lifecycle hook (when configured), which drains the worker gracefully before termination. The autoscaler keeps its own drain + skip-if-busy gate, so the hook is additive safety — no regression for standalone deployments without the hook.

## Changes

- `KillInstance` → single `TerminateInstanceInAutoScalingGroup` call (AWS only; GCP/Azure already use single-call deletes).
- `ifaces.Autoscaling`: add `TerminateInstanceInAutoScalingGroup`, drop unused `DetachInstances`; `ifaces.EC2`: drop unused `TerminateInstances`. Mocks regenerated.
- Remove the dead `detachedNotTerminatedInstances()` reaper (the atomic call can no longer create that state). General stray-instance detection is unchanged.
- Tests updated.

## Companion change

The Terraform module deploys the lifecycle hook alongside the autoscaler and grants the new `autoscaling:TerminateInstanceInAutoScalingGroup` IAM permission (spacelift-io/terraform-aws-spacelift-workerpool-on-ec2). This binary should release as **v2.8.0** — the module's v7.2 upgrade requires it.

## Testing

`go build` / `go vet` / `go test ./...` all green (128 tests).