### PR TITLE
fix: worker drain fails on self-hosted backends without availableAt

### DIFF
--- a/internal/aws_controller_test.go
+++ b/internal/aws_controller_test.go
@@ -407,7 +407,7 @@ func TestDrainWorker_WorkerNotBusy_SucceedsAndReportsDrained(t *testing.T) {
 		}),
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.Worker{Busy: false}
+		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.WorkerLegacy{Busy: false}
 	}).Return(nil)
 
 	drained, err := sut.DrainWorker(t.Context(), workerID)
@@ -431,7 +431,7 @@ func TestDrainWorker_WorkerBusy_UndrainCallFails_SendsCorrectInput(t *testing.T)
 		}),
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.Worker{Busy: true}
+		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.WorkerLegacy{Busy: true}
 	}).Return(nil)
 
 	var capturedUndrainParams map[string]any
@@ -472,7 +472,7 @@ func TestDrainWorker_WorkerBusy_UndrainCallFails_ReturnsError(t *testing.T) {
 		}),
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.Worker{Busy: true}
+		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.WorkerLegacy{Busy: true}
 	}).Return(nil)
 
 	mockSpacelift.On(
@@ -507,7 +507,7 @@ func TestDrainWorker_WorkerBusy_UndrainCallSucceeds_ReportsNotDrained(t *testing
 		}),
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.Worker{Busy: true}
+		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.WorkerLegacy{Busy: true}
 	}).Return(nil)
 
 	mockSpacelift.On(

--- a/internal/azure_controller_test.go
+++ b/internal/azure_controller_test.go
@@ -419,7 +419,7 @@ func TestAzureDrainWorker_WorkerNotBusy_SucceedsAndReportsDrained(t *testing.T) 
 		}),
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.Worker{Busy: false}
+		args.Get(1).(*internal.WorkerDrainSet).Worker = internal.WorkerLegacy{Busy: false}
 	}).Return(nil)
 
 	drained, err := sut.DrainWorker(t.Context(), workerID)

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) DrainWorker(ctx context.Context, workerID string) (drained 
 
 	span.SetAttributes(attribute.String("worker_id", workerID))
 
-	var worker *Worker
+	var worker *WorkerLegacy
 
 	if worker, err = c.workerDrainSet(ctx, workerID, true); err != nil {
 		err = fmt.Errorf("could not drain worker: %w", err)
@@ -195,7 +195,7 @@ func (c *Controller) DrainWorker(ctx context.Context, workerID string) (drained 
 	return false, nil
 }
 
-func (c *Controller) workerDrainSet(ctx context.Context, workerID string, drain bool) (worker *Worker, err error) {
+func (c *Controller) workerDrainSet(ctx context.Context, workerID string, drain bool) (worker *WorkerLegacy, err error) {
 	ctx, span := c.Tracer.Start(ctx, fmt.Sprintf("spacelift.worker.setdrain.%t", drain))
 	defer span.End()
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -17,8 +17,10 @@ type Worker struct {
 	Metadata    string `graphql:"metadata" json:"metadata"`
 }
 
-// WorkerLegacy is used when querying backends that don't support availableAt.
-// This allows the autoscaler to work with older Spacelift versions.
+// WorkerLegacy is the Worker shape without availableAt. It backs both the
+// legacy worker-pool query (for backends that predate availableAt) and the
+// drain mutation, which never needs availableAt and must keep working against
+// those older backends.
 type WorkerLegacy struct {
 	ID        string `graphql:"id" json:"id"`
 	Busy      bool   `graphql:"busy" json:"busy"`

--- a/internal/worker_drain_set.go
+++ b/internal/worker_drain_set.go
@@ -1,5 +1,8 @@
 package internal
 
+// WorkerDrainSet is the workerDrainSet mutation. Its return type is WorkerLegacy
+// (not Worker) on purpose: the drain result never needs availableAt, and
+// selecting it would break self-hosted backends whose schema predates the field.
 type WorkerDrainSet struct {
-	Worker Worker `graphql:"workerDrainSet(workerPool: $workerPoolId, id: $workerId, drain: $drain)"`
+	Worker WorkerLegacy `graphql:"workerDrainSet(workerPool: $workerPoolId, id: $workerId, drain: $drain)"`
 }

--- a/internal/worker_drain_set_test.go
+++ b/internal/worker_drain_set_test.go
@@ -1,0 +1,44 @@
+package internal_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shurcooL/graphql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacelift-io/awsautoscalr/internal"
+)
+
+// The drain mutation is built by the same GraphQL client that derives its
+// selection set from struct tags. It must not request availableAt: self-hosted
+// backends whose schema predates that field reject the whole operation
+// ("Cannot query field \"availableAt\" on type \"Worker\"."), and the runtime
+// nil-check fallback never runs because no response is returned at all.
+func TestWorkerDrainSetMutation_DoesNotSelectAvailableAt(t *testing.T) {
+	var capturedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		// Response omits availableAt so it decodes against both the old (Worker)
+		// and fixed (WorkerLegacy) mutation return types.
+		_, _ = io.WriteString(w, `{"data":{"workerDrainSet":{"id":"w1","busy":false,"createdAt":0,"drained":true,"metadata":""}}}`)
+	}))
+	defer srv.Close()
+
+	client := graphql.NewClient(srv.URL, srv.Client())
+
+	err := client.Mutate(context.Background(), &internal.WorkerDrainSet{}, map[string]any{
+		"workerPoolId": graphql.ID("wp1"),
+		"workerId":     graphql.ID("w1"),
+		"drain":        graphql.Boolean(true),
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, capturedBody, "workerDrainSet", "sanity: request should carry the drain mutation")
+	require.NotContains(t, capturedBody, "availableAt", "drain mutation must not select availableAt (breaks pre-availableAt self-hosted backends)")
+}


### PR DESCRIPTION
In v2.5.0 the scaling algorithm was improved to protect workers that recently consumed work — they have proved they are needed. This reduces unnecessary scale-downs: before, any idle worker was eligible for termination whenever the pool was not busy. With the improved algorithm, scaling should be less spiky.

The behavior was meant to be opt-in behind `AUTOSCALING_SCALE_DOWN_DELAY_USE_IDLE_TIME`, so that we don't break compatibility with self-hosted versions that lack the required `availableAt` GraphQL field, which exposes when a worker became free. However, the implementation had a mistake: the read path works, but the write path — triggered when the autoscaler decides to scale — still queried for the new field. That breaks compatibility, causing a GraphQL schema error.

## Fix

The `workerDrainSet` mutation returned the shared `Worker` struct, so the GraphQL client baked `availableAt` into the mutation's selection set. Because drain never reads `availableAt`, the mutation now returns `WorkerLegacy` (the `Worker` shape without `availableAt`). This is always safe — no flag needed, unlike the read path — and keeps drains working against backends both with and without the field.

A regression test sends the real drain mutation through the GraphQL client against an `httptest` server and asserts the wire query excludes `availableAt`.

[CU-869dyhaay](https://app.clickup.com/t/2384866/869dyhaay)
