### PR TITLE
docs: point users to the official worker pool modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Spacelift worker pool autoscaler
 
+> [!IMPORTANT]
+> **You almost certainly don't need to deploy this utility yourself.** Spacelift maintains official Terraform modules that provision a complete worker pool for you:
+>
+> - **AWS**: [terraform-aws-spacelift-workerpool-on-ec2](https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2)
+> - **Azure**: [terraform-azure-spacelift-workerpool](https://github.com/spacelift-io/terraform-azure-spacelift-workerpool)
+> - **GCP**: [terraform-google-spacelift-workerpool](https://github.com/spacelift-io/terraform-google-spacelift-workerpool)
+>
+> Wrapping this binary in your own module means re-implementing automation the official modules already provide, and missing pieces of it can lead to the autoscaler killing workers that are still processing runs.
+
 This utility is designed to be executed periodically for a single combination of a Spacelift worker pool and a cloud provider's autoscaling group which provides the worker pool with workers.
 
 ## Supported Cloud Providers


### PR DESCRIPTION
## Summary

- Adds a prominent callout at the top of the README directing users to the official Terraform worker pool modules (AWS, Azure, GCP) instead of deploying the autoscaler manually.

## Changes

1. **README.md**: Added an `IMPORTANT` admonition above the intro linking the three official modules and warning that wrapping this binary in a custom module means re-implementing automation the official modules already provide — which can result in the autoscaler terminating workers that are still processing runs.

## Context

A customer built their own Terraform module around this binary without realizing official modules exist. Their module was missing the lifecycle automation, so long-running jobs were killed when the autoscaler scaled workers in, corrupting state. This callout makes the official path unmissable for anyone landing on this repo first.